### PR TITLE
feat(core): allows user to create/use different config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ bootstrap_install/server_credentials
 
 # User Specific
 settings/
-tasks/ansible_bash.vars
+tasks/*ansible_bash.vars
 
 # IDE specific
 /.vscode

--- a/playbook.ci_config.yml
+++ b/playbook.ci_config.yml
@@ -23,12 +23,12 @@
     - name: Copy VivumLab config file into place
       template:
         src: "{{ playbook_dir }}/roles/vivumlab_config/templates/config.yml"
-        dest: "{{ playbook_dir }}/settings_ci/config.yml"
+        dest: "{{ playbook_dir }}/settings_ci/prod-config.yml"
 
     - name: Copy VivumLab vault file into place
       template:
         src: "{{ playbook_dir }}/roles/vivumlab_config/templates/vault.yml"
-        dest: "{{ playbook_dir }}/settings_ci/vault.yml"
+        dest: "{{ playbook_dir }}/settings_ci/prod-vault.yml"
 
     - name: Generate Ansible inventory file
       template:
@@ -38,5 +38,5 @@
     - name: Copy ansible_bash.vars file into place
       template:
         src: "{{ playbook_dir }}/roles/vivumlab_config/templates/ansible_bash.vars"
-        dest: "{{ playbook_dir }}/tasks/ansible_bash.vars"
+        dest: "{{ playbook_dir }}/tasks/prod-ansible_bash.vars"
 ...

--- a/roles/vivumlab_config/tasks/main.yml
+++ b/roles/vivumlab_config/tasks/main.yml
@@ -8,12 +8,12 @@
 - name: Copy VivumLab config file into place
   template:
     src: "config.yml"
-    dest: "{{ playbook_dir }}/settings/config.yml"
+    dest: "{{ playbook_dir }}/settings/prod-config.yml"
 
 - name: Copy VivumLab vault file into place
   template:
     src: "vault.yml"
-    dest: "{{ playbook_dir }}/settings/vault.yml"
+    dest: "{{ playbook_dir }}/settings/prod-vault.yml"
 
 - name: Generate Ansible inventory file
   template:
@@ -23,5 +23,5 @@
 - name: Copy ansible_bash.vars file into place
   template:
     src: "ansible_bash.vars"
-    dest: "{{ playbook_dir }}/tasks/ansible_bash.vars"
+    dest: "{{ playbook_dir }}/tasks/prod-ansible_bash.vars"
     owner: "{{ ansible_user_id }}"

--- a/tasks/ConfigTasks.sh
+++ b/tasks/ConfigTasks.sh
@@ -10,7 +10,7 @@ Task::config(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo_local
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -20,19 +20,19 @@ Task::config(){
   [ -f ~/.vlab_vault_pass ] || Task::generate_ansible_pass
 
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.config.yml || colorize light_red "error: config"
   highlight "Encrypting Secrets in the Vault"
-  Task::run_docker ansible-vault encrypt $_config_dir/$(user_config)vault.yml || colorize light_red "error: config: encrypt"
+  Task::run_docker ansible-vault encrypt $_config_dir/$_user_config-vault.yml || colorize light_red "error: config: encrypt"
 }
 
 #Show the Configuration settings for a given service
 Task::show_config(){
   : @desc "Shows the configuration settings for the specified service"
   : @param service! "The name of the service. Use: service=serviceName"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
-  Task::run_docker yq r -C "settings/$(user_config)config.yml" $_service
+  Task::run_docker yq r -C "settings/$_user_config-config.yml" $_service
 
 }
 
@@ -58,7 +58,7 @@ Task::config_reset() {
 Task::set(){
   : @desc "Set a configuration variable"
   : @param rest% "Configuration Key to set"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   "Task::decrypt user_config=$_user_config"
 
@@ -68,13 +68,13 @@ Task::set(){
   value="${_rest[$key]}"
 
   # Try to figure out where key is defined
-  FILE=settings/$(user_config)config.yml
+  FILE=settings/$_user_config-config.yml
   SETTING_VALUE=$(Task::run_docker yq r "$FILE" "$key" "$value")
   if [ -z ${SETTING_VALUE} ]; then
-      FILE=settings/$(user_config)vault.yml
+      FILE=settings/$_user_config-vault.yml
       SETTING_VALUE=$(Task::run_docker yq r "$FILE" "$key" "$value")
       if [ -z ${SETTING_VALUE} ]; then
-          echo "Key does not exist in $(user_config)config.yml nor $(user_config)vault.yml."
+          echo "Key does not exist in $_user_config-config.yml nor $_user_config-vault.yml."
           # Re-encrypt vault
           "Task::encrypt user_config=$_user_config"
           exit 1

--- a/tasks/ConfigTasks.sh
+++ b/tasks/ConfigTasks.sh
@@ -10,6 +10,7 @@ Task::config(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo_local
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -19,18 +20,19 @@ Task::config(){
   [ -f ~/.vlab_vault_pass ] || Task::generate_ansible_pass
 
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.config.yml || colorize light_red "error: config"
   highlight "Encrypting Secrets in the Vault"
-  Task::run_docker ansible-vault encrypt $_config_dir/vault.yml || colorize light_red "error: config: encrypt"
+  Task::run_docker ansible-vault encrypt $_config_dir/$(user_config)vault.yml || colorize light_red "error: config: encrypt"
 }
 
 #Show the Configuration settings for a given service
 Task::show_config(){
   : @desc "Shows the configuration settings for the specified service"
   : @param service! "The name of the service. Use: service=serviceName"
+  : @param user_config "Prefix of the user-cloned config files"
 
-  Task::run_docker yq r -C "settings/config.yml" $_service
+  Task::run_docker yq r -C "settings/$(user_config)config.yml" $_service
 
 }
 
@@ -56,8 +58,9 @@ Task::config_reset() {
 Task::set(){
   : @desc "Set a configuration variable"
   : @param rest% "Configuration Key to set"
+  : @param user_config "Prefix of the user-cloned config files"
 
-  Task::decrypt
+  "Task::decrypt user_config=$_user_config"
 
   # ( set -o posix ; set )
   local key value
@@ -65,15 +68,15 @@ Task::set(){
   value="${_rest[$key]}"
 
   # Try to figure out where key is defined
-  FILE=settings/config.yml
+  FILE=settings/$(user_config)config.yml
   SETTING_VALUE=$(Task::run_docker yq r "$FILE" "$key" "$value")
   if [ -z ${SETTING_VALUE} ]; then
-      FILE=settings/vault.yml
+      FILE=settings/$(user_config)vault.yml
       SETTING_VALUE=$(Task::run_docker yq r "$FILE" "$key" "$value")
       if [ -z ${SETTING_VALUE} ]; then
-          echo "Key does not exist in config.yml nor vault.yml."
+          echo "Key does not exist in $(user_config)config.yml nor $(user_config)vault.yml."
           # Re-encrypt vault
-          Task::encrypt
+          "Task::encrypt user_config=$_user_config"
           exit 1
       fi
   fi
@@ -86,5 +89,5 @@ Task::set(){
   NEW_SETTING_VALUE=$(Task::run_docker yq r "$FILE" "$key" "$value")
   colorize green "New setting value: " ${NEW_SETTING_VALUE}
 
-  Task::encrypt
+  "Task::encrypt user_config=$_user_config"
 }

--- a/tasks/CoreTasks.sh
+++ b/tasks/CoreTasks.sh
@@ -120,28 +120,28 @@ Task::git_sync() {
 # Encrypt the vault
 Task::encrypt(){
   : @desc "Encrypts the vault"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   highlight "Encrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault encrypt settings/$(user_config)vault.yml  || colorize light_red "error: encrypt"
-  sudo chmod 640 settings/$(user_config)vault.yml
-  sudo chown $userID:$groupID settings/$(user_config)vault.yml
+  Task::run_docker ansible-vault encrypt settings/$_user_config-vault.yml  || colorize light_red "error: encrypt"
+  sudo chmod 640 settings/$_user_config-vault.yml
+  sudo chown $userID:$groupID settings/$_user_config-vault.yml
   highlight "Vault encrypted!"
 }
 
 # Decrypts the vault
 Task::decrypt(){
   : @desc "Decrypts the vault"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   highlight "Decrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault decrypt settings/$(user_config)vault.yml || colorize light_red "error: decrypt"
-  sudo chmod 640 settings/$(user_config)vault.yml
-  sudo chown $userID:$groupID settings/$(user_config)vault.yml
+  Task::run_docker ansible-vault decrypt settings/$_user_config-vault.yml || colorize light_red "error: decrypt"
+  sudo chmod 640 settings/$_user_config-vault.yml
+  sudo chown $userID:$groupID settings/$_user_config-vault.yml
   highlight "Vault decrypted!"
 }
 
@@ -153,14 +153,14 @@ Task::uninstall(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
 
   highlight "Uninstall VivumLab Completely"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory -t deploy playbook.remove.yml || colorize light_red "error: uninstall"
   highlight "Uninstall Complete"
 }
@@ -170,10 +170,10 @@ Task::restore() {
   : @desc "Restore a server from backups. Assuming backups were running"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory restore.yml  || colorize light_red "error: restore"
 }
 
@@ -208,9 +208,9 @@ Task::ci(){
       colorize light_red "Creating an empty Vault"
       echo "blank_on_purpose: True" > $_config_dir/vault.yml
   fi
-  if [[ ! -f tasks/ansible_bash.vars ]]; then
+  if [[ ! -f tasks/prod-ansible_bash.vars ]]; then
     colorize light_red "Creating ansible_bash.vars file"
-    echo "PASSWORDLESS_SSHKEY=''" > tasks/ansible_bash.vars
+    echo "PASSWORDLESS_SSHKEY=''" > tasks/prod-ansible_bash.vars
   fi
 
   highlight "Creating or Updating ci config file"

--- a/tasks/CoreTasks.sh
+++ b/tasks/CoreTasks.sh
@@ -120,26 +120,28 @@ Task::git_sync() {
 # Encrypt the vault
 Task::encrypt(){
   : @desc "Encrypts the vault"
+  : @param user_config "Prefix of the user-cloned config files"
 
   highlight "Encrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault encrypt settings/vault.yml  || colorize light_red "error: encrypt"
-  sudo chmod 640 settings/vault.yml
-  sudo chown $userID:$groupID settings/vault.yml
+  Task::run_docker ansible-vault encrypt settings/$(user_config)vault.yml  || colorize light_red "error: encrypt"
+  sudo chmod 640 settings/$(user_config)vault.yml
+  sudo chown $userID:$groupID settings/$(user_config)vault.yml
   highlight "Vault encrypted!"
 }
 
 # Decrypts the vault
 Task::decrypt(){
   : @desc "Decrypts the vault"
+  : @param user_config "Prefix of the user-cloned config files"
 
   highlight "Decrypting Vault"
     local userID=$(id -u)
     local groupID=$(id -g)
-  Task::run_docker ansible-vault decrypt settings/vault.yml || colorize light_red "error: decrypt"
-  sudo chmod 640 settings/vault.yml
-  sudo chown $userID:$groupID settings/vault.yml
+  Task::run_docker ansible-vault decrypt settings/$(user_config)vault.yml || colorize light_red "error: decrypt"
+  sudo chmod 640 settings/$(user_config)vault.yml
+  sudo chown $userID:$groupID settings/$(user_config)vault.yml
   highlight "Vault decrypted!"
 }
 
@@ -151,13 +153,14 @@ Task::uninstall(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
 
   highlight "Uninstall VivumLab Completely"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory -t deploy playbook.remove.yml || colorize light_red "error: uninstall"
   highlight "Uninstall Complete"
 }
@@ -167,9 +170,10 @@ Task::restore() {
   : @desc "Restore a server from backups. Assuming backups were running"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory restore.yml  || colorize light_red "error: restore"
 }
 

--- a/tasks/LifecyleTasks.sh
+++ b/tasks/LifecyleTasks.sh
@@ -8,14 +8,14 @@ Task::deploy(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
 
   highlight "Deploying VivumLab"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.vivumlab.yml || colorize light_red "error: deploy"
 }
 
@@ -27,7 +27,7 @@ Task::restart(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -36,7 +36,7 @@ Task::restart(){
 
   highlight "Restarting all services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.restart.yml || colorize light_red "error: restart"
   highlight "Services restarted"
 }
@@ -47,10 +47,10 @@ Task::restart_one(){
   : @param service! "Service Name"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: restart_one"
   highlight "Restarted ${_service}"
 }
@@ -63,7 +63,7 @@ Task::stop(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -72,7 +72,7 @@ Task::stop(){
 
   highlight "Stopping all services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.stop.yml || colorize light_red "error: stop"
   highlight "Services stopped"
 }
@@ -86,7 +86,7 @@ Task::stop_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -94,7 +94,7 @@ Task::stop_one(){
   Task::config
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml  || colorize light_red "error: stop_one"
   highlight "Stopped ${_service}"
 }
@@ -108,7 +108,7 @@ Task::remove_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -117,7 +117,7 @@ Task::remove_one(){
 
   highlight "Removing data for ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml || colorize light_red "error: remove_one"
   highlight "Removed ${_service}"
 }
@@ -131,7 +131,7 @@ Task::reset_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -140,14 +140,14 @@ Task::reset_one(){
 
   highlight "Resetting ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml || colorize light_red "error: reset_one: stop"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml  || colorize light_red "error: reset_one: remove"
   highlight "Redeploying ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: reset_one: deploy"
   highlight "Reset ${_service}"
 }

--- a/tasks/LifecyleTasks.sh
+++ b/tasks/LifecyleTasks.sh
@@ -8,13 +8,14 @@ Task::deploy(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
 
   highlight "Deploying VivumLab"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.vivumlab.yml || colorize light_red "error: deploy"
 }
 
@@ -26,6 +27,7 @@ Task::restart(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -34,7 +36,7 @@ Task::restart(){
 
   highlight "Restarting all services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.restart.yml || colorize light_red "error: restart"
   highlight "Services restarted"
 }
@@ -45,9 +47,10 @@ Task::restart_one(){
   : @param service! "Service Name"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: restart_one"
   highlight "Restarted ${_service}"
 }
@@ -60,6 +63,7 @@ Task::stop(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -68,7 +72,7 @@ Task::stop(){
 
   highlight "Stopping all services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.stop.yml || colorize light_red "error: stop"
   highlight "Services stopped"
 }
@@ -82,6 +86,7 @@ Task::stop_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -89,7 +94,7 @@ Task::stop_one(){
   Task::config
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml  || colorize light_red "error: stop_one"
   highlight "Stopped ${_service}"
 }
@@ -103,6 +108,7 @@ Task::remove_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -111,7 +117,7 @@ Task::remove_one(){
 
   highlight "Removing data for ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml || colorize light_red "error: remove_one"
   highlight "Removed ${_service}"
 }
@@ -125,6 +131,7 @@ Task::reset_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -133,14 +140,14 @@ Task::reset_one(){
 
   highlight "Resetting ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.stop.yml || colorize light_red "error: reset_one: stop"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.remove.yml  || colorize light_red "error: reset_one: remove"
   highlight "Redeploying ${_service}"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: reset_one: deploy"
   highlight "Reset ${_service}"
 }

--- a/tasks/SanityCheckTasks.sh
+++ b/tasks/SanityCheckTasks.sh
@@ -43,17 +43,17 @@ Task::check_for_settings(){
         colorize light_red "Creating passwords directory"
         mkdir -p settings/passwords
     fi
-    if [[ ! -f settings/config.yml ]]; then
+    if [[ ! -f settings/prod-config.yml ]]; then
         colorize light_red "Creating an empty config file"
-        echo "blank_on_purpose: True" > settings/config.yml
+        echo "blank_on_purpose: True" > settings/prod-config.yml
     fi
-    if [[ ! -f settings/vault.yml ]]; then
+    if [[ ! -f settings/prod-vault.yml ]]; then
         colorize light_red "Creating an empty Vault"
-        echo "blank_on_purpose: True" > settings/vault.yml
+        echo "blank_on_purpose: True" > settings/prod-vault.yml
     fi
-    if [[ ! -f tasks/ansible_bash.vars ]]; then
+    if [[ ! -f tasks/prod-ansible_bash.vars ]]; then
       colorize light_red "Creating ansible_bash.vars file"
-      echo "PASSWORDLESS_SSHKEY=''" > tasks/ansible_bash.vars
+      echo "PASSWORDLESS_SSHKEY=''" > tasks/prod-ansible_bash.vars
     fi
 }
 

--- a/tasks/TerraformTasks.sh
+++ b/tasks/TerraformTasks.sh
@@ -8,7 +8,7 @@ Task::terraform(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -19,7 +19,7 @@ Task::terraform(){
   highlight "Deploying cloud server"
   # Generate Terraform files
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.terraform.yml || colorize light_red "error: terraform: deploy"
 
   # Run terraform

--- a/tasks/TerraformTasks.sh
+++ b/tasks/TerraformTasks.sh
@@ -8,6 +8,7 @@ Task::terraform(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -18,7 +19,7 @@ Task::terraform(){
   highlight "Deploying cloud server"
   # Generate Terraform files
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.terraform.yml || colorize light_red "error: terraform: deploy"
 
   # Run terraform

--- a/tasks/UpdateTasks.sh
+++ b/tasks/UpdateTasks.sh
@@ -8,7 +8,7 @@ Task::update() {
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -17,10 +17,10 @@ Task::update() {
 
   highlight "Updating VivumLab Services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.restart.yml || colorize light_red "error: update: restart"
   highlight "Services Updated"
 }
@@ -34,7 +34,7 @@ Task::update_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -43,10 +43,10 @@ Task::update_one(){
   Task::config
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update_one"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: update_one: restart"
   highlight "$_service Updated"
 }

--- a/tasks/UpdateTasks.sh
+++ b/tasks/UpdateTasks.sh
@@ -8,6 +8,7 @@ Task::update() {
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -16,10 +17,10 @@ Task::update() {
 
   highlight "Updating VivumLab Services"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.restart.yml || colorize light_red "error: update: restart"
   highlight "Services Updated"
 }
@@ -33,6 +34,7 @@ Task::update_one(){
   : @param build true "Forces to build the image locally"
   : @param debug true "Debugs ansible-playbook commands"
   : @param cache true "Allows the build to use the cache"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::logo
   Task::build $(build_check) $(force_check) $(cache_check)
@@ -41,10 +43,10 @@ Task::update_one(){
   Task::config
 
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory -t deploy playbook.vivumlab.yml || colorize light_red "error: update_one"
   Task::run_docker ansible-playbook $(debug_check) $(sshkey_path) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   --extra-vars='{"services":["'${_service}'"]}' -i inventory playbook.restart.yml || colorize light_red "error: update_one: restart"
   highlight "$_service Updated"
 }

--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -49,10 +49,10 @@ Task::service_edit() {
   : @param service "Service Name"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
+  --extra-vars="@$_config_dir/$_user_config-config.yml" --extra-vars="@$_config_dir/$_user_config-vault.yml" \
   -i inventory playbook.service-edit.yml || colorize light_red "error: service_edit"
 }
 
@@ -90,17 +90,16 @@ Task::setup_sshkey() {
 Task::clone_config() {
   : @desc "Clones the VivumLab config in its current state"
   : @param config_dir="settings"
-  : @param user_config "Prefix of the user-cloned config files"
+  : @param user_config="prod" "Prefix of the user-cloned config files"
 
   read -p "What would you like to prefix the new files with? " clone_config_prefix
   printf "cloning configs"
 
   Task::decrypt
-  cp $_config_dir/config.yml $_config_dir/${clone_config_prefix}-config.yml
-  cp $_config_dir/vault.yml $_config_dir/${clone_config_prefix}-vault.yml
-  cp tasks/ansible_bash.vars tasks/${clone_config_prefix}-ansible_bash.vars
-  Task::encrypt
-  "Task::encrypt user_config=$_user_config"
+  cp $_config_dir/prod-config.yml $_config_dir/${clone_config_prefix}-config.yml
+  cp $_config_dir/prod-vault.yml $_config_dir/${clone_config_prefix}-vault.yml
+  cp tasks/prod-ansible_bash.vars tasks/${clone_config_prefix}-ansible_bash.vars
+  "Task::encrypt user_config=${clone_config_prefix}"
 
 }
 

--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -95,7 +95,7 @@ Task::clone_config() {
   read -p "What would you like to prefix the new files with? " clone_config_prefix
   printf "cloning configs"
 
-  "Task::decrypt user_config=$_user_config"
+  Task::decrypt
   cp $_config_dir/config.yml $_config_dir/${clone_config_prefix}-config.yml
   cp $_config_dir/vault.yml $_config_dir/${clone_config_prefix}-vault.yml
   cp tasks/ansible_bash.vars tasks/${clone_config_prefix}-ansible_bash.vars

--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -49,9 +49,10 @@ Task::service_edit() {
   : @param service "Service Name"
   : @param config_dir="settings"
   : @param debug true "Debugs ansible-playbook commands"
+  : @param user_config "Prefix of the user-cloned config files"
 
   Task::run_docker ansible-playbook $(debug_check) \
-  --extra-vars="@$_config_dir/config.yml" --extra-vars="@$_config_dir/vault.yml" \
+  --extra-vars="@$_config_dir/$(user_config)config.yml" --extra-vars="@$_config_dir/$(user_config)vault.yml" \
   -i inventory playbook.service-edit.yml || colorize light_red "error: service_edit"
 }
 
@@ -84,6 +85,23 @@ Task::setup_sshkey() {
 
   Task::create_sshkey
   Task::copy_sshkey
+}
+
+Task::clone_config() {
+  : @desc "Clones the VivumLab config in its current state"
+  : @param config_dir="settings"
+  : @param user_config "Prefix of the user-cloned config files"
+
+  read -p "What would you like to prefix the new files with? " clone_config_prefix
+  printf "cloning configs"
+
+  "Task::decrypt user_config=$_user_config"
+  cp $_config_dir/config.yml $_config_dir/${clone_config_prefix}-config.yml
+  cp $_config_dir/vault.yml $_config_dir/${clone_config_prefix}-vault.yml
+  cp tasks/ansible_bash.vars tasks/${clone_config_prefix}-ansible_bash.vars
+  Task::encrypt
+  "Task::encrypt user_config=$_user_config"
+
 }
 
 # Provides the user with a terminal rendered 'contact us' doc

--- a/yamllint.conf
+++ b/yamllint.conf
@@ -17,7 +17,7 @@ ignore: |
   roles/vivumlab_api_deploy/tasks/conf.d/middlewares.yaml
   roles/cockpit/templates/traefik.yaml
   roles/homeassistant/templates/traefik.yaml
-  config.yml
+  *-config.yml
   mkdocs.yml
   .gitlab-ci.yml
   website/

--- a/yamllint.conf
+++ b/yamllint.conf
@@ -17,6 +17,7 @@ ignore: |
   roles/vivumlab_api_deploy/tasks/conf.d/middlewares.yaml
   roles/cockpit/templates/traefik.yaml
   roles/homeassistant/templates/traefik.yaml
+  package_template/config.yml
   *-config.yml
   mkdocs.yml
   .gitlab-ci.yml


### PR DESCRIPTION
allows user to create and to use different config files with the various vivumlab playbooks, using an extra user_config option.

vlab clone_config, sets a prefix, so the user can differentiate between the original and the user defined config files.


eg. answering vlab clone_config prompt, with... test1; will create test1-config.yml, test1-vault.yml, and test1-ansible_bash.vars.


Test and review, pleae