### PR TITLE
fix(docs): linebreak in docs fixed

### DIFF
--- a/docs/software/adguardhome.md
+++ b/docs/software/adguardhome.md
@@ -8,7 +8,7 @@
 
 ## Information
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ adguardhome.version }}
 
 ## SETUP

--- a/docs/software/airsonic.md
+++ b/docs/software/airsonic.md
@@ -8,7 +8,7 @@
 
 ## Information
 
-**Docker Image:** https://hub.docker.com/r/linuxserver/airsonic \
+**Docker Image:** https://hub.docker.com/r/linuxserver/airsonic  
 **Current Image Version:** {{ airsonic.version }}
 
 ## SETUP

--- a/docs/software/apache2.md
+++ b/docs/software/apache2.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ apache2.version }}
 
 ## SETUP

--- a/docs/software/authelia.md
+++ b/docs/software/authelia.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ authelia.version }}
 
 ## SETUP

--- a/docs/software/barcodebuddy.md
+++ b/docs/software/barcodebuddy.md
@@ -13,7 +13,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ barcodebuddy.version }}
 
 ## SETUP

--- a/docs/software/beets.md
+++ b/docs/software/beets.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ beets.version }}
 
 ## SETUP

--- a/docs/software/bitwarden.md
+++ b/docs/software/bitwarden.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ bitwarden.version }}
 
 ## SETUP

--- a/docs/software/bookstack.md
+++ b/docs/software/bookstack.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ bookstack.version }}
 
 ## SETUP

--- a/docs/software/bulletnotes.md
+++ b/docs/software/bulletnotes.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ bulletnotes.version }}
 
 ## SETUP

--- a/docs/software/calibre.md
+++ b/docs/software/calibre.md
@@ -11,7 +11,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ calibre.version }}
 
 ## SETUP

--- a/docs/software/chowdown.md
+++ b/docs/software/chowdown.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ chowdown.version }}
 
 ## SETUP

--- a/docs/software/codeserver.md
+++ b/docs/software/codeserver.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ codeserver.version }}
 
 ## SETUP

--- a/docs/software/codimd.md
+++ b/docs/software/codimd.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ codimd.version }}
 
 ## SETUP

--- a/docs/software/darksky.md
+++ b/docs/software/darksky.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ dark_sky.version }}
 
 ## SETUP

--- a/docs/software/digikam.md
+++ b/docs/software/digikam.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ digikam.version }}
 
 ## SETUP

--- a/docs/software/drone.md
+++ b/docs/software/drone.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ drone.version }}
 
 ## SETUP

--- a/docs/software/duckdns.md
+++ b/docs/software/duckdns.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ duckdns.version }}
 
 ## SETUP

--- a/docs/software/duplicati.md
+++ b/docs/software/duplicati.md
@@ -10,7 +10,7 @@ For Windows, macOS and Linux.
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ duplicati.version }}
 
 ## SETUP

--- a/docs/software/elkstack.md
+++ b/docs/software/elkstack.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ elkstack.version }}
 
 ## SETUP

--- a/docs/software/emby.md
+++ b/docs/software/emby.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ emby.version }}
 
 ## SETUP

--- a/docs/software/erpnext.md
+++ b/docs/software/erpnext.md
@@ -8,7 +8,7 @@
 
 ## Information
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ erpnext.version }}
 
 ## SETUP

--- a/docs/software/ethercalc.md
+++ b/docs/software/ethercalc.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ ethercalc.version }}
 
 ## SETUP

--- a/docs/software/factorio.md
+++ b/docs/software/factorio.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ factorio.version }}
 
 ## SETUP

--- a/docs/software/firefly.md
+++ b/docs/software/firefly.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ firefly_iii.version }}
 
 ## SETUP

--- a/docs/software/folding_at_home.md
+++ b/docs/software/folding_at_home.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ folding_at_home.version }}
 
 ## SETUP

--- a/docs/software/freshrss.md
+++ b/docs/software/freshrss.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ freshrss.version }}
 
 ## SETUP

--- a/docs/software/funkwhale.md
+++ b/docs/software/funkwhale.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ funkwhale.version }}
 
 ## SETUP

--- a/docs/software/ghost.md
+++ b/docs/software/ghost.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ ghost.version }}
 
 ## SETUP

--- a/docs/software/gitea.md
+++ b/docs/software/gitea.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ gitea.version }}
 
 ## SETUP

--- a/docs/software/gitlab.md
+++ b/docs/software/gitlab.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ gitlab.version }}
 
 ## SETUP

--- a/docs/software/gotify.md
+++ b/docs/software/gotify.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ gotify.version }}
 
 ## SETUP

--- a/docs/software/grafana.md
+++ b/docs/software/grafana.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ grafana.version }}
 
 ## SETUP

--- a/docs/software/grocy.md
+++ b/docs/software/grocy.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ grocy.version }}
 
 ## SETUP

--- a/docs/software/guacamole.md
+++ b/docs/software/guacamole.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ guacamole.version }}
 
 ## SETUP

--- a/docs/software/healthchecks.md
+++ b/docs/software/healthchecks.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ healthchecks.version }}
 
 ## SETUP

--- a/docs/software/heimdall.md
+++ b/docs/software/heimdall.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ heimdall.version }}
 
 ## SETUP

--- a/docs/software/homeassistant.md
+++ b/docs/software/homeassistant.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ homeassistant.version }}
 
 ## SETUP

--- a/docs/software/homebridge.md
+++ b/docs/software/homebridge.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ homebridge.version }}
 
 ## SETUP

--- a/docs/software/homedash.md
+++ b/docs/software/homedash.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ homedash.version }}
 
 ## SETUP

--- a/docs/software/hubzilla.md
+++ b/docs/software/hubzilla.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ hubzilla.version }}
 
 ## SETUP

--- a/docs/software/huginn.md
+++ b/docs/software/huginn.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ huginn.version }}
 
 ## SETUP

--- a/docs/software/inventario.md
+++ b/docs/software/inventario.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ inventario.version }}
 
 ## SETUP

--- a/docs/software/invoiceninja.md
+++ b/docs/software/invoiceninja.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ invoiceninja.version }}
 
 ## SETUP

--- a/docs/software/jackett.md
+++ b/docs/software/jackett.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ jackett.version }}
 
 ## SETUP

--- a/docs/software/jellyfin.md
+++ b/docs/software/jellyfin.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ jellyfin.version }}
 
 ## SETUP

--- a/docs/software/jenkins.md
+++ b/docs/software/jenkins.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ jenkins.version }}
 
 ## SETUP

--- a/docs/software/keycloak.md
+++ b/docs/software/keycloak.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ keycloak.version }}
 
 ## SETUP

--- a/docs/software/kibitzr.md
+++ b/docs/software/kibitzr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ kibitzr.version }}
 
 ## SETUP

--- a/docs/software/lazylibrarian.md
+++ b/docs/software/lazylibrarian.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ lazylibrarian.version }}
 
 ## SETUP

--- a/docs/software/lidarr.md
+++ b/docs/software/lidarr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ lidarr.version }}
 
 ## SETUP

--- a/docs/software/mailu.md
+++ b/docs/software/mailu.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ mailu.version }}
 
 ## SETUP

--- a/docs/software/mashio.md
+++ b/docs/software/mashio.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ mashio.version }}
 
 ## SETUP

--- a/docs/software/matomo.md
+++ b/docs/software/matomo.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ matomo.version }}
 
 ## SETUP

--- a/docs/software/matterbridge.md
+++ b/docs/software/matterbridge.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ matterbridge.version }}
 
 ## SETUP

--- a/docs/software/mayan.md
+++ b/docs/software/mayan.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ mayan.version }}
 
 ## SETUP

--- a/docs/software/minecraft.md
+++ b/docs/software/minecraft.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ minecraft.version }}
 
 ## SETUP

--- a/docs/software/minecraftbedrockserver.md
+++ b/docs/software/minecraftbedrockserver.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ minecraftbedrockserver.version }}
 
 ## SETUP

--- a/docs/software/miniflux.md
+++ b/docs/software/miniflux.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ miniflux.version }}
 
 ## SETUP

--- a/docs/software/minio.md
+++ b/docs/software/minio.md
@@ -9,7 +9,7 @@ Minio is an S3 storage utility.
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ minio.version }}
 
 ## SETUP

--- a/docs/software/monica.md
+++ b/docs/software/monica.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ monicahq.version }}
 
 ## SETUP

--- a/docs/software/mstream.md
+++ b/docs/software/mstream.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ mstream.version }}
 
 ## SETUP

--- a/docs/software/mylar.md
+++ b/docs/software/mylar.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ mylar.version }}
 
 ## SETUP

--- a/docs/software/n8n.md
+++ b/docs/software/n8n.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ n8n.version }}
 
 ## SETUP

--- a/docs/software/netdata.md
+++ b/docs/software/netdata.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ netdata.version }}
 
 ## SETUP

--- a/docs/software/nextcloud.md
+++ b/docs/software/nextcloud.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ nextcloud.version }}
 
 ## SETUP

--- a/docs/software/nodered.md
+++ b/docs/software/nodered.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ nodered.version }}
 
 ## SETUP

--- a/docs/software/octoprint.md
+++ b/docs/software/octoprint.md
@@ -20,7 +20,7 @@ Using the pattern:
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ octoprint.version }}
 
 ## SETUP

--- a/docs/software/ombi.md
+++ b/docs/software/ombi.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ ombi.version }}
 
 ## SETUP

--- a/docs/software/openldap.md
+++ b/docs/software/openldap.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ openldap.version }}
 
 ## SETUP

--- a/docs/software/openvpn.md
+++ b/docs/software/openvpn.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ openvpn.version }}
 
 ## SETUP

--- a/docs/software/organizr.md
+++ b/docs/software/organizr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ organizr.version }}
 
 ## SETUP

--- a/docs/software/ownphotos.md
+++ b/docs/software/ownphotos.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ ownphotos.version }}
 
 ## SETUP

--- a/docs/software/paperless.md
+++ b/docs/software/paperless.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ paperless.version }}
 
 ## SETUP

--- a/docs/software/peertube.md
+++ b/docs/software/peertube.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ peertube.version }}
 
 ## SETUP

--- a/docs/software/photoprism.md
+++ b/docs/software/photoprism.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ photoprism.version }}
 
 ## SETUP

--- a/docs/software/pihole.md
+++ b/docs/software/pihole.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ pihole.version }}
 
 ## SETUP

--- a/docs/software/piwigo.md
+++ b/docs/software/piwigo.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ piwigo.version }}
 
 ## SETUP

--- a/docs/software/pixelfed.md
+++ b/docs/software/pixelfed.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ pixelfed.version }}
 
 ## SETUP

--- a/docs/software/pleroma.md
+++ b/docs/software/pleroma.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ pleroma.version }}
 
 ## SETUP

--- a/docs/software/plex.md
+++ b/docs/software/plex.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ plex.version }}
 
 ## SETUP

--- a/docs/software/poli.md
+++ b/docs/software/poli.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ poli.version }}
 
 ## SETUP

--- a/docs/software/portainer.md
+++ b/docs/software/portainer.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ portainer.version }}
 
 ## SETUP

--- a/docs/software/privatebin.md
+++ b/docs/software/privatebin.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ privatebin.version }}
 
 ## SETUP

--- a/docs/software/qbittorrent.md
+++ b/docs/software/qbittorrent.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ qbittorrent.version }}
 
 ## SETUP

--- a/docs/software/radarr.md
+++ b/docs/software/radarr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ radarr.version }}
 
 ## SETUP

--- a/docs/software/readarr.md
+++ b/docs/software/readarr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ readarr.version }}
 
 ## SETUP

--- a/docs/software/rsshub.md
+++ b/docs/software/rsshub.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ rsshub.version }}
 
 ## SETUP

--- a/docs/software/sabnzbd.md
+++ b/docs/software/sabnzbd.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ sabnzbd.version }}
 
 ## SETUP

--- a/docs/software/samba.md
+++ b/docs/software/samba.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ samba.version }}
 
 ## SETUP

--- a/docs/software/searx.md
+++ b/docs/software/searx.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ searx.version }}
 
 ## SETUP

--- a/docs/software/shinobi.md
+++ b/docs/software/shinobi.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ shinobi.version }}
 
 ## SETUP

--- a/docs/software/sickchill.md
+++ b/docs/software/sickchill.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ sickchill.version }}
 
 ## SETUP

--- a/docs/software/simply-shorten.md
+++ b/docs/software/simply-shorten.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ simply_shorten.version }}
 
 ## SETUP

--- a/docs/software/snibox.md
+++ b/docs/software/snibox.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ snibox.version }}
 
 ## SETUP

--- a/docs/software/sonarr.md
+++ b/docs/software/sonarr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ sonarr.version }}
 
 ## SETUP

--- a/docs/software/speedtest.md
+++ b/docs/software/speedtest.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ speedtest.version }}
 
 ## SETUP

--- a/docs/software/statping.md
+++ b/docs/software/statping.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ statping.version }}
 
 ## SETUP

--- a/docs/software/sui.md
+++ b/docs/software/sui.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ sui.version }}
 
 ## SETUP

--- a/docs/software/syncthing.md
+++ b/docs/software/syncthing.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ syncthing.version }}
 
 ## SETUP

--- a/docs/software/system-cockpit.md
+++ b/docs/software/system-cockpit.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** None
 
 ## SETUP

--- a/docs/software/taisun.md
+++ b/docs/software/taisun.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ taisun.version }}
 
 ## SETUP

--- a/docs/software/tautulli.md
+++ b/docs/software/tautulli.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ tautulli.version }}
 
 ## SETUP

--- a/docs/software/teedy.md
+++ b/docs/software/teedy.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ teedy.version }}
 
 ## SETUP

--- a/docs/software/thelounge.md
+++ b/docs/software/thelounge.md
@@ -10,7 +10,7 @@ when you aren't.
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ thelounge.version }}
 
 ## SETUP

--- a/docs/software/tick.md
+++ b/docs/software/tick.md
@@ -13,7 +13,7 @@ It can also take data from [Home Assistant](software/homeassistant) and many oth
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version Telegraf:** {{ tick.telegraf_version }} \
 **Current Image Version Influxdb:** {{ tick.influxdb_version }} \
 **Current Image Version Chronograf:** {{ tick.chronograf_version }} \

--- a/docs/software/tiddlywiki.md
+++ b/docs/software/tiddlywiki.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ tiddlywiki.version }}
 
 ## SETUP

--- a/docs/software/transmission.md
+++ b/docs/software/transmission.md
@@ -11,7 +11,7 @@ VivumLab uses [docker-transmission-openvpn](https://github.com/haugene/docker-tr
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ transmission.version }}
 
 ## SETUP

--- a/docs/software/trilium.md
+++ b/docs/software/trilium.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ trilium.version }}
 
 ## SETUP

--- a/docs/software/turtl.md
+++ b/docs/software/turtl.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** None
 
 ## SETUP

--- a/docs/software/ubooquity.md
+++ b/docs/software/ubooquity.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ ubooquity.version }}
 
 ## SETUP

--- a/docs/software/unificontroller.md
+++ b/docs/software/unificontroller.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ unificontroller.version }}
 
 ## SETUP

--- a/docs/software/wallabag.md
+++ b/docs/software/wallabag.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ wallabag.version }}
 
 ## SETUP

--- a/docs/software/watchtower.md
+++ b/docs/software/watchtower.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ watchtower.version }}
 
 ## SETUP

--- a/docs/software/webdavserver.md
+++ b/docs/software/webdavserver.md
@@ -11,7 +11,7 @@ If you don't need all the extra from NextCloud/OwnCloud, this service could be w
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ webdavserver.version }}
 
 ## SETUP

--- a/docs/software/webtrees.md
+++ b/docs/software/webtrees.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ webtrees.version }}
 
 ## SETUP

--- a/docs/software/webvirtmgr.md
+++ b/docs/software/webvirtmgr.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ webvirtmgr.version }}
 
 ## SETUP

--- a/docs/software/wekan.md
+++ b/docs/software/wekan.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ wekan.version }}
 
 ## SETUP

--- a/docs/software/zammad.md
+++ b/docs/software/zammad.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ zammad.version }}
 
 ## Requirements Hardware

--- a/docs/software/zulip.md
+++ b/docs/software/zulip.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ zulip.version }}
 
 ## SETUP

--- a/package_template/docs/software/template.md
+++ b/package_template/docs/software/template.md
@@ -9,7 +9,7 @@
 ## Information
 
 
-**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!\
+**Docker Image:** !!! LINK TO DOCKER IMAGE/ DOCKER HUB !!!  
 **Current Image Version:** {{ PackageFileName.version }}
 
 ## SETUP


### PR DESCRIPTION
Second try to fix the line break in the docs.
This time I tested it when locally running `mkdocs serve`, MkDocs could not handle `\` and create a new line.

closes #136