### PR TITLE
refactor(ssh): separated create and copy sshkey functions

### DIFF
--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -73,11 +73,15 @@ Task::create_sshkey() {
 }
 
 Task::copy_sshkey() {
+  : @desc "Allows user to copy an existing ssh key"
+  
   echo "Copying keys over to the machine, located at $(vlab_ip)"
   ssh-copy-id -i "$HOME/.ssh/$(pwless_sshkey).pub" "$(vlab_ssh_user)@$(vlab_ip)" -p "$(vlab_port)" || colorize light_red "error: create_sshkey: copying keys"
 }
 
 Task::setup_sshkey() {
+  : @desc "Creates and copies a non-existing SSH key"
+  
   Task::create_sshkey
   Task::copy_sshkey
 }

--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -74,14 +74,14 @@ Task::create_sshkey() {
 
 Task::copy_sshkey() {
   : @desc "Allows user to copy an existing ssh key"
-  
+
   echo "Copying keys over to the machine, located at $(vlab_ip)"
   ssh-copy-id -i "$HOME/.ssh/$(pwless_sshkey).pub" "$(vlab_ssh_user)@$(vlab_ip)" -p "$(vlab_port)" || colorize light_red "error: create_sshkey: copying keys"
 }
 
 Task::setup_sshkey() {
   : @desc "Creates and copies a non-existing SSH key"
-  
+
   Task::create_sshkey
   Task::copy_sshkey
 }

--- a/tasks/UserActionTasks.sh
+++ b/tasks/UserActionTasks.sh
@@ -70,9 +70,16 @@ Task::create_sshkey() {
 
   echo "Creating $(pwless_sshkey) and $(pwless_sshkey).pub"
   ssh-keygen -q -N "$KEY_PASS" -C "VivumLab@$(domain_check)" -f "$HOME/.ssh/$(pwless_sshkey)"|| colorize light_red "error: create_sshkey"
+}
 
+Task::copy_sshkey() {
   echo "Copying keys over to the machine, located at $(vlab_ip)"
   ssh-copy-id -i "$HOME/.ssh/$(pwless_sshkey).pub" "$(vlab_ssh_user)@$(vlab_ip)" -p "$(vlab_port)" || colorize light_red "error: create_sshkey: copying keys"
+}
+
+Task::setup_sshkey() {
+  Task::create_sshkey
+  Task::copy_sshkey
 }
 
 # Provides the user with a terminal rendered 'contact us' doc


### PR DESCRIPTION
Separated crete and copy sshkey tasks.

Useful, when you are breaking down a server, and rebuilding it, again and again while testing (but you still want to use the old keys)