### PR TITLE
refactor(core): installs utils package for semanage. CentOS

### DIFF
--- a/roles/vivumlab_setup/tasks/centinstall.yml
+++ b/roles/vivumlab_setup/tasks/centinstall.yml
@@ -18,6 +18,7 @@
       - iotop
       - mosh
       - nfs-utils
+      - policycoreutils-python-utils
       - screen
       - sudo
       - vim-enhanced


### PR DESCRIPTION
Semanage may be required for some users, especially if they want to use a custom SSH port (which is good practise)