### PR TITLE
refactor(precommit): fix for Vivum not recognising precommit install

### DIFF
--- a/tasks/SanityCheckTasks.sh
+++ b/tasks/SanityCheckTasks.sh
@@ -125,7 +125,7 @@ Task::check_ssh_keys() {
 }
 
 Task::check_for_precommit () {
-  pcver=$(pre-commit --version > /dev/null 2>&1 || echo "0.0.0")
+  pcver=$(pre-commit --version || echo "0.0.0")
   reqpy="3.6.1"
   reqpc="2.6.0"
 
@@ -137,7 +137,7 @@ Task::check_for_precommit () {
 
   if [ "$(printf '%s\n' "$reqpy" "$pyver" | sort -V | head -n1)" = "$reqpy" ]; then
    if [ "$(printf '%s\n' "$reqpc" "$pcver" | sort -V | head -n1)" = "$reqpc" ]; then
-     [ ! -f .git/pre-commit ] || pre-commit install && pre-commit install --install-hooks
+     [ ! -f .git/pre-commit ] || pre-commit install && pre-commit install --install-hooks # > /dev/null 2>&1
    else
      echo "Pre-commit is not installed"
      echo "Contributions via git, require pre-commit. Run vlab dev_setup, to begin"

--- a/tasks/SanityCheckTasks.sh
+++ b/tasks/SanityCheckTasks.sh
@@ -137,7 +137,7 @@ Task::check_for_precommit () {
 
   if [ "$(printf '%s\n' "$reqpy" "$pyver" | sort -V | head -n1)" = "$reqpy" ]; then
    if [ "$(printf '%s\n' "$reqpc" "$pcver" | sort -V | head -n1)" = "$reqpc" ]; then
-     [ ! -f .git/pre-commit ] || pre-commit install && pre-commit install --install-hooks # > /dev/null 2>&1
+     [ ! -f .git/pre-commit ] || pre-commit install && pre-commit install --install-hooks > /dev/null 2>&1
    else
      echo "Pre-commit is not installed"
      echo "Contributions via git, require pre-commit. Run vlab dev_setup, to begin"


### PR DESCRIPTION
So I was getting this (not necessarily an error, but this..) erroneous message when running deploy

>Pre-commit is not installed
Contributions via git, require pre-commit. Run vlab dev_setup, to begin
after your deployment has finished, of course

So I toyed with it, and found the culprit.

However, the code can be placed, where I put the comment.. line 139
>     [ ! -f .git/pre-commit ] || pre-commit install && pre-commit install --install-hooks # > /dev/null 2>&1

and it will not display, this message..

>pre-commit installed at .git/hooks/pre-commit

I figured I would leave this choice to you.
if you want the message, remove the comment and everything after it,
if you don't want it, remove the '#'

Entirely up to you.