### PR TITLE
refactor(traefik): not exposing open ports unless required

### DIFF
--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -126,6 +126,8 @@ traefik:
   auth: "{{ vault.traefik.auth }}"
   expose_internally: "{{ vault.traefik.expose_internally }}"
   expose_externally: "{{ vault.traefik.expose_externally }}"
+  ping: "{{ vault.traefik.ping | default(False) }}"
+  metrics: "{{ vault.traefik.metrics | default(False) }}"
   # Enable sendAnonymousUsage?
   # Reference: https://docs.traefik.io/master/contributing/data-collection/
   send_anonymous_usage: "{{ vault.traefik.send_anonymous_usage }}"

--- a/roles/vivumlab_config/templates/vault.yml
+++ b/roles/vivumlab_config/templates/vault.yml
@@ -47,8 +47,10 @@ vault:
     domain: {{ vault.traefik.domain | default(False) }}
     subdomain: {{ vault.traefik.subdomain | default("traefik") }}
     auth: {{ vault.traefik.auth | default(False) }}
-    expose_internally: {{ vault.traefik.expose_internally | default(True)  }}
-    expose_externally: {{ vault.traefik.expose_externally | default(False)  }}
+    expose_internally: {{ vault.traefik.expose_internally | default(True) }}
+    expose_externally: {{ vault.traefik.expose_externally | default(False) }}
+    ping: {{ vault.traefik.ping | default(False) }}
+    metrics: {{ vault.traefik.metrics | default(False) }}
     # Enable sendAnonymousUsage?
     # Reference: https://docs.traefik.io/master/contributing/data-collection/
     send_anonymous_usage: {{ vault.traefik.send_anonymous_usage | default("false")  }}

--- a/roles/vivumlab_deploy/templates/docker-compose.traefik.yml.j2
+++ b/roles/vivumlab_deploy/templates/docker-compose.traefik.yml.j2
@@ -22,7 +22,9 @@ services:
 {% endif %}
       - "80:80"
       - "443:443"
+{% if bastion.enable %}
       - "2222:2222"
+{% endif %}
 {% if traefik.additional_env_vars %}
     environment:
 {% for item in traefik.additional_env_vars | dict2items %}

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -42,10 +42,10 @@ entryPoints:
 #  smtp:
 #    address: :25
 # {% endif %}
-{% if bastion.enable %}
-  ssh:
-    address: ":2222"
-{% endif %}
+#{% if bastion.enable %}
+#  ssh:
+#    address: ":2222"
+#{% endif %}
 {% if traefik.expose_internally or traefik.expose_externally %}
   #ping@internal
   ping:

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -42,10 +42,10 @@ entryPoints:
 #  smtp:
 #    address: :25
 # {% endif %}
-#{% if bastion.enable %}
+# {% if bastion.enable %}
 #  ssh:
 #    address: ":2222"
-#{% endif %}
+# {% endif %}
 {% if traefik.expose_internally or traefik.expose_externally %}
   #ping@internal
   ping:

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -38,10 +38,10 @@ entryPoints:
             sans:
               - "*.{{ domain }}"
 {% endif %}
-{% if healthchecks.enable or bastion.enable %}
-  smtp:
-    address: :25
-{% endif %}
+# {% if healthchecks.enable %}
+#  smtp:
+#    address: :25
+# {% endif %}
 {% if bastion.enable %}
   ssh:
     address: ":2222"

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -54,7 +54,7 @@ entryPoints:
   metrics:
     address: ":8082"
 {% endif %}
-    
+
 {% if healthchecks.enable %}
 #Health
 ping:
@@ -86,7 +86,7 @@ providers:
   file:
     directory: /conf.d
     watch: true
-    
+
 {% if traefik.expose_internally or traefik.expose_externally %}
 api:
   dashboard: true

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -46,12 +46,14 @@ entryPoints:
   ssh:
     address: ":2222"
 {% endif %}
+{% if traefik.expose_internally or traefik.expose_externally %}
   #ping@internal
   ping:
     address: ":8081"
   #metrics@internal
   metrics:
     address: ":8082"
+{% endif %}
     
 {% if healthchecks.enable %}
 #Health
@@ -59,6 +61,7 @@ ping:
   entryPoint: "ping"
   manualRouting: false
 {% endif %}
+{% if traefik.expose_internally or traefik.expose_externally %}
 #Metrics
 metrics:
   prometheus:
@@ -71,6 +74,7 @@ metrics:
       - 0.3
       - 1.2
       - 5.0
+{% endif %}
 
 providers:
   providersThrottleDuration: 2s
@@ -82,10 +86,12 @@ providers:
   file:
     directory: /conf.d
     watch: true
-
+    
+{% if traefik.expose_internally or traefik.expose_externally %}
 api:
   dashboard: true
   insecure: true
+{% endif %}
 
 log:
   level: ERROR

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -38,22 +38,27 @@ entryPoints:
             sans:
               - "*.{{ domain }}"
 {% endif %}
-
+{% if healthchecks.enable %}
   smtp: # for healthchecks incoming emails
     address: :25
+{% endif %}
+{% if bastion.enable %}
   ssh:
     address: ":2222"
+{% endif %}
   #ping@internal
   ping:
     address: ":8081"
   #metrics@internal
   metrics:
     address: ":8082"
-
+    
+{% if healthchecks.enable %}
 #Health
 ping:
   entryPoint: "ping"
   manualRouting: false
+{% endif %}
 #Metrics
 metrics:
   prometheus:

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -38,8 +38,8 @@ entryPoints:
             sans:
               - "*.{{ domain }}"
 {% endif %}
-{% if healthchecks.enable %}
-  smtp: # for healthchecks incoming emails
+{% if healthchecks.enable or bastion.enable %}
+  smtp:
     address: :25
 {% endif %}
 {% if bastion.enable %}

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -46,22 +46,24 @@ entryPoints:
 #  ssh:
 #    address: ":2222"
 # {% endif %}
-{% if traefik.expose_internally or traefik.expose_externally %}
+{% if traefik.ping %}
   #ping@internal
   ping:
     address: ":8081"
+{% endif %}
+{% if traefik.metrics %}
   #metrics@internal
   metrics:
     address: ":8082"
 {% endif %}
 
-{% if healthchecks.enable %}
+{% if traefik.ping %}
 #Health
 ping:
   entryPoint: "ping"
   manualRouting: false
 {% endif %}
-{% if traefik.expose_internally or traefik.expose_externally %}
+{% if traefik.metrics %}
 #Metrics
 metrics:
   prometheus:


### PR DESCRIPTION
For now, the typical use case.. deploying own the users own infrastructure, not using bastion, and not deploying mailu; the fix detailed below should work.

Fixes:
- Unless bastion is enabled, port 2222 is not exposed.
- Unless healthchecks OR bastion is enabled, port 25 in not exposed.

To consider, after merging (I would prefer these get sorted prior to merging, @denis-ev @codefriar):
- gitea ssh port should be changed from 2222 (will clash with bastion)
- vagrant 'ansible port' should be changed from 2222
- if healthchecks or bastion enable option is changed, after deploying; Vivum will need to restart traefik, after redeploying (still considering the best way to do this)