### PR TITLE
refactor(setup): fix for docker-compose location issues

### DIFF
--- a/roles/vivumlab_setup/tasks/centinstall.yml
+++ b/roles/vivumlab_setup/tasks/centinstall.yml
@@ -96,7 +96,7 @@
     executable: pip3
   become: yes
 
-- name: Docker-compose Location Check
+- name: Check for Docker-compose
   stat:
     path: /usr/bin/docker-compose
   register: compose_location

--- a/roles/vivumlab_setup/tasks/debinstall.yml
+++ b/roles/vivumlab_setup/tasks/debinstall.yml
@@ -104,6 +104,19 @@
     executable: pip3
   become: yes
 
+- name: Check for Docker-compose
+  stat:
+    path: /usr/bin/docker-compose
+  register: compose_location
+
+- name: Symlink docker-compose
+  file:
+    src: /usr/local/bin/docker-compose
+    dest: /usr/bin/docker-compose
+    state: link
+  become: yes
+  when: compose_location.stat.exists == False
+
 - name: Start Docker service
   systemd:
     state: started


### PR DESCRIPTION
FIX:
When pip installs docker-compose, it gets installed in /usr/local/bin, not /usr/bin, as per the service files.
It appears to happen on debian and on centos.