### PR TITLE
refactor(config): remove unnecessary commenting

### DIFF
--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -90,6 +90,24 @@ Run against all the files (optional)
 **`pre-commit run --all-files`**
 
 ## Supporting multiple architectures
-Some, if not most, docker images will support more than the typical 64 bit architecture; this is very relevant, and very welcome in VivumLab. With the growing popularity of Raspberry PI, using VivumLab with this cost effective, and compact option is obvious and desirable for users.
+Some, if not most, docker images will support more than the typical 64 bit architecture; this is very relevant, and very welcome in VivumLab. With the growing popularity of more compact hardware, such as the Raspberry PI, using VivumLab with this cost effective, and compact option is obvious and desirable for users.
 
-<MORE TO COME!!>
+You may notice that in the config.yml file, there are three options, relating to three different architectures, for almost every service;
+example:
+```
+ amd64: False
+ arm64: False
+ armv7: False
+```
+These exist, as to tell the user which architecture the service is supported on. AMD64 may be relevant to the standard home server install of Debian or CentOS, ARM64 for older 64 bit versions of Raspberry PI (former known as Raspbian), and ARMv7 for the newer versions (possibly known as Raspberry PI OS).
+For example, if the current image for Jellyfin supports ARMv7, but you have only tested AMD64 (and it works), then make the following changes to the config.yml file:
+```
+jellyfin:
+  ('enable' <-> 'version' options here, as usual) 
+  amd64: Verfied
+  arm64: Unsupported
+  armv7: Supported
+```
+If an architecture is not supported, either 'Unsupported' or 'False' can be used.
+
+As a developer, when you add a service or otherwise verify a service, make sure you edit the config.yml file, and add the relevent information, before pushing your changes to Github.

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -1,24 +1,24 @@
 # Developer Tips
 
 ## Labels 
-`bug` is for bugs. :)
-`chore` describes necessary, though possibly annoying changes
-`cleanup` cleaning or consolidating code
-`documentation` improvements or additions to documentation
-`duplicate` labels something as it previously exists. The core team will review these, regularly
-`enhancement` new feature or request; not necessarily relating to a service
-`future release` this should only be used by the Core team 
-`good first issue` this should only be used by the Core team
-`help wanted` use this if you are working on something and you need help. Want to contribute? look for this label
-`invalid` this should only be used by the Core team
-`needs testing` testing is required
-`priority` fix ASAP!! all hands on deck. Confused on how to contribute? look for this label
-`question` USe this if further information is requuired
-`ready for review` tells the Core team, that its ready for review
-`ready to merge` tells the Core team, that its ready to be merged
-`security` nything that helps make VivumLab more secure
-`service` should only be placed on a service/ new service
-`WIP` acronym for Work in progress. Use this if you are working on something but don't need help
+`bug` - is for bugs. :)
+`chore` - describes necessary, though possibly annoying changes
+`cleanup` - cleaning or consolidating code
+`documentation` - improvements or additions to documentation
+`duplicate` - labels something as it previously exists. The core team will review these, regularly
+`enhancement` - new feature or request; not necessarily relating to a service
+`future release` - this should only be used by the Core team 
+`good first issue` - this should only be used by the Core team
+`help wanted` - use this if you are working on something and you need help. Want to contribute? look for this label
+`invalid` - this should only be used by the Core team
+`needs testing` - testing is required
+`priority` - fix ASAP!! all hands on deck. Confused on how to contribute? look for this label
+`question` - Use this if further information is requuired
+`ready for review` - tells the Core team, that its ready for review
+`ready to merge` - tells the Core team, that its ready to be merged
+`security` - anything that helps make VivumLab more secure
+`service` - should only be placed on a service/ new service
+`WIP` - acronym for Work in progress. Use this if you are working on something but don't need help
 
 ## Creating migrations
 

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -1,12 +1,24 @@
 # Developer Tips
 
-## Labels
-
-`feat` is for any new features. features changes or adds to how VivumLab itself deploys/operates.
-
-`package` is for new packages people would like added to VivumLab. These should not be marked as `enhancement`s.
-
+## Labels 
 `bug` is for bugs. :)
+`chore` describes necessary, though possibly annoying changes
+`cleanup` cleaning or consolidating code
+`documentation` improvements or additions to documentation
+`duplicate` labels something as it previously exists. The core team will review these, regularly
+`enhancement` new feature or request; not necessarily relating to a service
+`future release` this should only be used by the Core team 
+`good first issue` this should only be used by the Core team
+`help wanted` use this if you are working on something and you need help. Want to contribute? look for this label
+`invalid` this should only be used by the Core team
+`needs testing` testing is required
+`priority` fix ASAP!! all hands on deck. Confused on how to contribute? look for this label
+`question` USe this if further information is requuired
+`ready for review` tells the Core team, that its ready for review
+`ready to merge` tells the Core team, that its ready to be merged
+`security` nything that helps make VivumLab more secure
+`service` should only be placed on a service/ new service
+`WIP` acronym for Work in progress. Use this if you are working on something but don't need help
 
 ## Creating migrations
 
@@ -76,3 +88,8 @@ From the VivumLab root folder (where you run the **`vlab`** commands from), run:
 
 Run against all the files (optional)
 **`pre-commit run --all-files`**
+
+## Supporting multiple architectures
+Some, if not most, docker images will support more than the typical 64 bit architecture; this is very relevant, and very welcome in VivumLab. With the growing popularity of Raspberry PI, using VivumLab with this cost effective, and compact option is obvious and desirable for users.
+
+<MORE TO COME!!>

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -1,13 +1,13 @@
 # Developer Tips
 
-## Labels 
+## Labels
 `bug` - is for bugs. :)
 `chore` - describes necessary, though possibly annoying changes
 `cleanup` - cleaning or consolidating code
 `documentation` - improvements or changes to documentation
 `duplicate` - may be a duplicate/ may previously exist. The core team will review these, regularly
 `enhancement` - new feature or request; not necessarily relating to a service
-`future release` - this should only be used by the Core team 
+`future release` - this should only be used by the Core team
 `good first issue` - this should only be used by the Core team
 `help wanted` - use this if you are working on something and you need help. Want to contribute? look for this label
 `invalid` - this should only be used by the Core team
@@ -103,7 +103,7 @@ These exist, as to tell the user which architecture the service is supported on.
 For example, if the current image for Jellyfin supports ARMv7, but you have only tested AMD64 (and it works), then make the following changes to the config.yml file:
 ```
 jellyfin:
-  ('enable' <-> 'version' options here, as usual) 
+  ('enable' <-> 'version' options here, as usual)
   amd64: Verfied
   arm64: Unsupported
   armv7: Supported

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -13,7 +13,7 @@
 `invalid` - this should only be used by the Core team
 `needs testing` - testing is required
 `priority` - fix ASAP!! all hands on deck. Confused on how to contribute? look for this label
-`question` - Use this if further information is requuired
+`question` - use this if further information is requuired
 `ready for review` - tells the Core team, that its ready for review
 `ready to merge` - tells the Core team, that its ready to be merged
 `security` - anything that helps make VivumLab more secure

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -4,7 +4,7 @@
 `bug` - is for bugs. :)
 `chore` - describes necessary, though possibly annoying changes
 `cleanup` - cleaning or consolidating code
-`documentation` - improvements or additions to documentation
+`documentation` - improvements or changes to documentation
 `duplicate` - labels something as it previously exists. The core team will review these, regularly
 `enhancement` - new feature or request; not necessarily relating to a service
 `future release` - this should only be used by the Core team 

--- a/docs/dev/Developer-Tips.md
+++ b/docs/dev/Developer-Tips.md
@@ -5,7 +5,7 @@
 `chore` - describes necessary, though possibly annoying changes
 `cleanup` - cleaning or consolidating code
 `documentation` - improvements or changes to documentation
-`duplicate` - labels something as it previously exists. The core team will review these, regularly
+`duplicate` - may be a duplicate/ may previously exist. The core team will review these, regularly
 `enhancement` - new feature or request; not necessarily relating to a service
 `future release` - this should only be used by the Core team 
 `good first issue` - this should only be used by the Core team

--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -156,9 +156,9 @@ docs:
   domain: {{ docs.domain | default(False) }}
   subdomain: {{ docs.subdomain | default("docs") }}
   version: {{ docs.version | default("1.1.2") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 apache2:
   enable: {{ apache2.enable | default(False) }}
   https_only: {{ apache2.https_only | default(False) }}
@@ -166,9 +166,9 @@ apache2:
   domain: {{ apache2.domain | default(False) }}
   subdomain: {{ apache2.subdomain | default("apache2") }}
   version: {{ apache2.version | default("2.4") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 apple_health_influx:
   enable: {{ apple_health_influx.enable | default(False) }}
   https_only: {{ apple_health_influx.https_only | default(False) }}
@@ -176,9 +176,9 @@ apple_health_influx:
   domain: {{ apple_health_influx.domain | default(False) }}
   subdomain: {{ apple_health_influx.subdomain | default("apple_health_influx") }}
   version: {{apple_health_influx.version | default("cron") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 adguardhome:
   enable: {{ adguardhome.enable | default(False) }}
   https_only: {{ adguardhome.https_only | default(False) }}
@@ -186,9 +186,9 @@ adguardhome:
   domain: {{ adguardhome.domain | default(False) }}
   subdomain: {{ adguardhome.subdomain | default("adguardhome")}}
   version: {{ adguardhome.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 airsonic:
   enable: {{ airsonic.enable | default(False) }}
   https_only: {{ airsonic.https_only | default(False) }}
@@ -196,9 +196,9 @@ airsonic:
   domain: {{ airsonic.domain | default(False) }}
   subdomain: {{ airsonic.subdomain | default("airsonic") }}
   version: {{ airsonic.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 authelia:
   enable: {{ authelia.enable | default(False) }}
   https_only: {{ authelia.https_only | default(False) }}
@@ -209,9 +209,9 @@ authelia:
   version: {{ authelia.version | default("latest") }}
   redis_version: {{ authelia.redis_version | default("5.0.5-alpine") }}
   db_version: {{ authelia.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   redirect_url:  {{ authelia.redirect_url | default("https://organizr." + domain) }}
   # Determines how verbose the logs are
   log_level: {{ authelia.log_level | default('debug') }}
@@ -252,9 +252,9 @@ barcodebuddy:
   domain: {{ barcodebuddy.domain | default(False) }}
   subdomain: {{ barcodebuddy.subdomain | default("barcodebuddy") }}
   version: {{ barcodebuddy.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 beets:
   enable: {{ beets.enable | default(False) }}
   https_only: {{ beets.https_only | default(False) }}
@@ -262,9 +262,9 @@ beets:
   domain: {{ beets.domain | default(False) }}
   subdomain: {{ beets.subdomain | default("beets") }}
   version: {{ beets.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 bitwarden:
   enable: {{ bitwarden.enable | default(False) }}
   https_only: {{ bitwarden.https_only | default(False) }}
@@ -272,9 +272,9 @@ bitwarden:
   domain: {{ bitwarden.domain  | default(False) }}
   subdomain: {{ bitwarden.subdomain  | default("bitwarden") }}
   version: {{ bitwarden.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   # Enable admin page
   # IMPORTANT: Activate HTTPS before enabling this feature, to avoid possible MITM attacks.
   # Reference: https://github.com/dani-garcia/bitwarden_rs/wiki/Enabling-admin-page
@@ -294,9 +294,9 @@ bookstack:
   subdomain: {{ bookstack.subdomain | default("bookstack") }}
   version: {{ bookstack.version | default("0.29.2") }}
   db_version: {{bookstack.db_version | default("5.7.21") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 bulletnotes:
   enable: {{ bulletnotes.enable | default(False) }}
   https_only: {{ bulletnotes.https_only | default(False) }}
@@ -305,9 +305,9 @@ bulletnotes:
   subdomain: {{ bulletnotes.subdomain | default("bulletnotes") }}
   version: {{ bulletnotes.version | default("latest") }}
   db_version: {{ bulletnotes.db_version | default("3.2.21") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 calibre:
   enable: {{ calibre.enable | default(False) }}
   https_only: {{ calibre.https_only | default(False) }}
@@ -316,9 +316,9 @@ calibre:
   subdomain: {{ calibre.subdomain | default("calibre") }}
   version: {{ calibre.version | default("latest") }}
   server_version: {{ calibre.server_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 chowdown:
   enable: {{ chowdown.enable | default(False) }}
   https_only: {{ chowdown.https_only | default(False) }}
@@ -326,9 +326,9 @@ chowdown:
   domain: {{ chowdown.domain | default(False) }}
   subdomain: {{ chowdown.subdomain | default("chowdown") }}
   version: {{ chowdown.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 cockpit:
   enable: {{ cockpit.enable | default(False) }}
   domain: {{ cockpit.domain | default(False) }}
@@ -340,9 +340,9 @@ codeserver:
   domain: {{ codeserver.domain | default(False) }}
   subdomain: {{ codeserver.subdomain | default("codeserver") }}
   version: {{ codeserver.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 codimd:
   enable: {{ codimd.enable | default(False) }}
   https_only: {{ codimd.https_only | default(False) }}
@@ -351,9 +351,9 @@ codimd:
   subdomain: {{ codimd.subdomain | default("codimd") }}
   version: {{ codimd.version | default("latest") }}
   db_version: {{ codimd.db_version | default("9.6-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 dark_sky:
   enable: {{ dark_sky.enable | default(False) }}
   https_only: {{ dark_sky.https_only | default(False) }}
@@ -361,9 +361,9 @@ dark_sky:
   domain: {{ dark_sky.domain | default(False) }}
   subdomain: {{ dark_sky.subdomain | default("dark_sky") }}
   version: {{ dark_sky.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 digikam:
   enable: {{ digikam.enable | default(False) }}
   https_only: {{ digikam.https_only | default(False) }}
@@ -371,9 +371,9 @@ digikam:
   domain: {{ digikam.domain | default(False) }}
   subdomain: {{ digikam.subdomain | default("digikam") }}
   version: {{ digikam.version | default("stable") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 drone:
   enable: {{ drone.enable | default(False) }}
   https_only: {{ drone.https_only | default(False) }}
@@ -382,9 +382,9 @@ drone:
   subdomain: {{ drone.subdomain | default("drone") }}
   version: {{ drone.version | default("1.0") }}
   agent_version: {{ drone.agent_version | default("1.0") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 {% raw %}
   gitea_id: "{{ vault.drone.gitea_id | default(False) }}"
   gitea_secret: "{{ vault.drone.gitea_secret | default(False) }}"
@@ -392,9 +392,9 @@ drone:
 duckdns:
   enable: {{ duckdns.enable | default(False) }}
   version: {{ duckdns.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 {% raw %}
   token: "{{ vault.duckdns.token | default(False) }}"
 {% endraw %}
@@ -405,9 +405,9 @@ duplicati:
   domain: {{ duplicati.domain | default(False) }}
   subdomain: {{ duplicati.subdomain | default("duplicati") }}
   version: {{ duplicati.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 elkstack:
   enable: {{ elkstack.enable | default(False) }}
   https_only: {{ elkstack.https_only | default(False) }}
@@ -415,9 +415,9 @@ elkstack:
   domain: {{ elkstack.domain | default(False) }}
   subdomain: {{ elkstack.subdomain | default("elkstack") }}
   version: {{ elkstack.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 emby:
   enable: {{ emby.enable | default(False) }}
   https_only: {{ emby.https_only | default(False) }}
@@ -425,9 +425,9 @@ emby:
   domain: {{ emby.domain | default(False) }}
   subdomain: {{ emby.subdomain | default("emby") }}
   version: {{ emby.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 erpnext:
   enable: {{ erpnext.enable | default(False) }}
   https_only: {{ erpnext.https_only | default(False) }}
@@ -437,9 +437,9 @@ erpnext:
   version: {{ erpnext.version | default("v11") }}
   db_version: {{ erpnext.db_version | default("10.3") }}
   redis_version: {{ erpnext.redis_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 ethercalc:
   enable: {{ ethercalc.enable | default(False) }}
   https_only: {{ ethercalc.https_only | default(False) }}
@@ -448,9 +448,9 @@ ethercalc:
   subdomain: {{ ethercalc.subdomain | default("ethercalc") }}
   version: {{ ethercalc.version | default("latest") }}
   redis_version: {{ ethercalc.redis_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 factorio:
   enable: {{ factorio.enable | default(False) }}
   https_only: {{ factorio.https_only | default(False) }}
@@ -458,9 +458,9 @@ factorio:
   domain: {{ factorio.domain | default(False) }}
   subdomain: {{ factorio.subdomain | default("factorio") }}
   version: {{ factorio.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 firefly_iii:
   enable: {{ firefly_iii.enable | default(False) }}
   https_only: {{ firefly_iii.https_only | default(False) }}
@@ -469,9 +469,9 @@ firefly_iii:
   subdomain: {{ firefly_iii.subdomain | default("firefly_iii") }}
   version: {{ firefly_iii.version | default("latest") }}
   db_version: {{ firefly_iii.db_version | default("12") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 folding_at_home:
   enable: {{ folding_at_home.enable | default(False) }}
   https_only: {{ folding_at_home.https_only | default(False) }}
@@ -479,9 +479,9 @@ folding_at_home:
   domain: {{ folding_at_home.domain | default(False) }}
   subdomain: {{ folding_at_home.subdomain | default("folding_at_home") }}
   version: {{ folding_at_home.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   username: {{ folding_at_home.username | default( default_username ) }}
   # Team VivumLab - https://stats.foldingathome.org/team/266976
   team: {{ folding_at_home.team | default( "266976" ) }}
@@ -494,9 +494,9 @@ freshrss:
   domain: {{ freshrss.domain | default(False) }}
   subdomain: {{ freshrss.subdomain | default("freshrss") }}
   version: {{ freshrss.version | default("alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 funkwhale:
   enable: {{ funkwhale.enable | default(False) }}
   https_only: {{ funkwhale.https_only | default(False) }}
@@ -504,9 +504,9 @@ funkwhale:
   domain: {{ funkwhale.domain| default(False) }}
   subdomain: {{ funkwhale.subdomain | default("funkwhale") }}
   version: {{ funkwhale.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 ghost:
   enable: {{ ghost.enable | default(False) }}
   https_only: {{ ghost.https_only | default(False) }}
@@ -514,9 +514,9 @@ ghost:
   domain: {{ ghost.domain | default(False) }}
   subdomain: {{ ghost.subdomain | default("ghost") }}
   version: {{ ghost.version | default("3-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 gitea:
   enable: {{ gitea.enable | default(False) }}
   https_only: {{ gitea.https_only | default(False) }}
@@ -525,9 +525,9 @@ gitea:
   subdomain: {{ gitea.subdomain | default("gitea") }}
   version: {{ gitea.version | default("1.11") }}
   db_version: {{ gitea.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   use_mariadb: {{ gitea.use_mariadb | default(True) }}
   gitea_ssh_port: {{ gitea.gitea_ssh_port | default(222) }}
 gitlab:
@@ -539,9 +539,9 @@ gitlab:
   version: {{ gitlab.version | default("latest") }}
   runner_version: {{ gitlab.runner_version | default("alpine") }}
   db_version: {{ gitlab.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   registry_version: {{ gitlab.registry_version | default("latest") }}
   # Currently using default AWS vault entries for region/access_key/secret_key
   aws_lfs_enabled: {{ gitlab.aws_lfs_enabled | default(False) }}
@@ -565,9 +565,9 @@ gotify:
   domain: {{ gotify.domain | default(False) }}
   subdomain: {{ gotify.subdomain | default("gotify") }}
   version: {{ gotify.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 grafana:
   enable: {{ grafana.enable | default(False) }}
   https_only: {{ grafana.https_only | default(False) }}
@@ -575,9 +575,9 @@ grafana:
   domain: {{ grafana.domain | default(False) }}
   subdomain: {{ grafana.subdomain | default("grafana") }}
   version: {{ grafana.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 grocy:
   enable: {{ grocy.enable | default(False) }}
   https_only: {{ grocy.https_only | default(False) }}
@@ -585,9 +585,9 @@ grocy:
   domain: {{ grocy.domain | default(False) }}
   subdomain: {{ grocy.subdomain | default("grocy") }}
   version: {{ grocy.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 guacamole:
   enable: {{ guacamole.enable | default(False) }}
   https_only: {{ guacamole.https_only | default(False) }}
@@ -597,9 +597,9 @@ guacamole:
   version: {{ guacamole.version | default("latest") }}
   db_version: {{ guacamole.db_version | default("latest") }}
   proxy_version: {{ guacamole.proxy_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 healthchecks:
   enable: {{ healthchecks.enable | default(False) }}
   https_only: {{ healthchecks.https_only | default(False) }}
@@ -607,9 +607,9 @@ healthchecks:
   domain: {{ healthchecks.domain | default(False) }}
   subdomain: {{ healthchecks.subdomain | default("healthchecks") }}
   version: {{ healthchecks.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 heimdall:
   enable: {{ heimdall.enable | default(False) }}
   https_only: {{ heimdall.https_only | default(False) }}
@@ -617,9 +617,9 @@ heimdall:
   domain: {{ heimdall.domain| default(False) }}
   subdomain: {{ heimdall.subdomain | default("heimdall") }}
   version: {{ heimdall.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 homeassistant:
   enable: {{ homeassistant.enable | default(False) }}
   https_only: {{ homeassistant.https_only | default(False) }}
@@ -627,9 +627,9 @@ homeassistant:
   domain: {{ homeassistant.domain | default(False) }}
   subdomain: {{ homeassistant.subdomain | default("homeassistant") }}
   version: {{ homeassistant.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   use_supervisord: {{ homeassistant.use_supervisord | default(False)}}
 homebridge:
   enable: {{ homebridge.enable | default(False) }}
@@ -638,9 +638,9 @@ homebridge:
   domain: {{ homebridge.domain | default(False) }}
   subdomain: {{ homebridge.subdomain | default("homebridge") }}
   version: {{homebridge.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 homedash:
   enable: {{ homedash.enable | default(False) }}
   https_only: {{ homedash.https_only | default(False) }}
@@ -648,9 +648,9 @@ homedash:
   domain: {{ homedash.domain | default(False) }}
   subdomain: {{ homedash.subdomain | default("homedash") }}
   version: {{ homedash.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 hubzilla:
   enable: {{ hubzilla.enable | default(False) }}
   https_only: {{ hubzilla.https_only | default(False) }}
@@ -660,9 +660,9 @@ hubzilla:
   version: {{ hubzilla.version | default("4.6") }}
   db_version: {{ hubzilla.db_version | default("12.2-alpine") }}
   web_version: {{ hubzilla.web_version | default("1.17.10-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 huginn:
   enable: {{ huginn.enable | default(False) }}
   https_only: {{ huginn.https_only | default(False) }}
@@ -671,9 +671,9 @@ huginn:
   subdomain: {{ huginn.subdomain | default("huginn") }}
   version: {{ huginn.version | default("latest") }}
   db_version: {{ huginn.db_version | default("10.3") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 inventario:
   enable: {{ inventario.enable | default(False) }}
   https_only: {{ inventario.https_only | default(False) }}
@@ -682,9 +682,9 @@ inventario:
   subdomain: {{ inventario.subdomain | default("inventario") }}
   version: {{ inventario.version | default("latest") }}
   db_version: {{ inventario.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 invoiceninja:
   enable: {{ invoiceninja.enable | default(False) }}
   https_only: {{ invoiceninja.https_only | default(False) }}
@@ -692,9 +692,9 @@ invoiceninja:
   domain: {{ invoiceninja.domain | default(False) }}
   subdomain: {{ invoiceninja.subdomain | default("invoiceninja")}}
   version: {{ invoiceninja.version | default("alpine-4") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 jackett:
   enable: {{ jackett.enable | default(False) }}
   https_only: {{ jackett.https_only | default(False) }}
@@ -702,9 +702,9 @@ jackett:
   domain: {{ jackett.domain | default(False) }}
   subdomain: {{ jackett.subdomain | default("jackett") }}
   version: {{ jackett.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 jellyfin:
   enable: {{ jellyfin.enable | default(False) }}
   https_only: {{ jellyfin.https_only | default(False) }}
@@ -712,9 +712,9 @@ jellyfin:
   domain: {{ jellyfin.domain | default(False) }}
   subdomain: {{ jellyfin.subdomain | default("jellyfin") }}
   version: {{ jellyfin.version | default ("10.6.4") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 jenkins:
   enable: {{ jenkins.enable | default(False) }}
   https_only: {{ jenkins.https_only | default(False) }}
@@ -723,9 +723,9 @@ jenkins:
   subdomain: {{ jenkins.subdomain | default("jenkins")}}
   allow_docker: {{ jenkins.allow_docker | default(False)}}
   version: {{ jenkins.version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 keycloak:
   enable: {{ keycloak.enable | default(False) }}
   https_only: {{ keycloak.https_only | default(False) }}
@@ -734,9 +734,9 @@ keycloak:
   subdomain: {{ keycloak.subdomain | default("keycloak")}}
   version: {{ keycloak.version | default("latest") }}
   db_version: {{ keycloak.db_version | default("alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 kibitzr:
   enable: {{ kibitzr.enable | default(False) }}
   https_only: {{ kibitzr.https_only | default(False) }}
@@ -744,9 +744,9 @@ kibitzr:
   domain: {{ kibitzr.domain | default(False) }}
   subdomain: {{ kibitzr.subdomain | default("kibitzr") }}
   version: {{ kibitzr.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 lazylibrarian:
   enable: {{ lazylibrarian.enable | default(False) }}
   https_only: {{ lazylibrarian.https_only | default(False) }}
@@ -754,9 +754,9 @@ lazylibrarian:
   domain: {{ lazylibrarian.domain | default(False) }}
   subdomain: {{ lazylibrarian.subdomain | default("lazylibrarian") }}
   version: {{lazylibrarian.version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 lidarr:
   enable: {{ lidarr.enable | default(False) }}
   https_only: {{ lidarr.https_only | default(False) }}
@@ -764,9 +764,9 @@ lidarr:
   domain: {{ lidarr.domain | default(False) }}
   subdomain: {{ lidarr.subdomain | default("lidarr") }}
   version: {{ lidarr.version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 mailu:
   enable: {{ mailu.enable | default(False) }}
   https_only: {{ mailu.https_only | default(False) }}
@@ -775,9 +775,9 @@ mailu:
   subdomain: {{ mailu.subdomain | default("mailu") }}
   version: {{ mailu.version | default ("1.7") }}
   redis_version: {{ mailu.redis_version | default ("alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   forward_to_smtp: {{ mailu.forward_to_smtp | default(False)  }}
 mashio:
   enable: {{ mashio.enable | default(False) }}
@@ -787,9 +787,9 @@ mashio:
   subdomain: {{ mashio.subdomain | default("mashio") }}
   version: {{ mashio.version | default ("latest") }}
   db_version: {{ mashio.db_version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 massivedecks:
   enable: {{ massivedecks.enable | default(False) }}
   https_only: {{ massivedecks.https_only | default(False) }}
@@ -798,9 +798,9 @@ massivedecks:
   subdomain: {{ massivedecks.subdomain | default("massivedecks") }}
   server_version: {{ massivedecks.server_version | default ("latest") }}
   client_version: {{ massivedecks.client_version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 matomo:
   enable: {{ matomo.enable | default(False) }}
   https_only: {{ matomo.https_only | default(False) }}
@@ -809,15 +809,15 @@ matomo:
   subdomain: {{ matomo.subdomain | default("matomo") }}
   version: {{ matomo.version | default ("latest") }}
   db_version: {{ matomo.db_version | default ("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 matterbridge:
   enable: {{ matterbridge.enable | default(False) }}
   version: {{ matterbridge.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 mayan:
   enable: {{ mayan.enable | default(False) }}
   https_only: {{ mayan.https_only | default(False) }}
@@ -828,9 +828,9 @@ mayan:
   db_version: {{ mayan.db_version | default("latest") }}
   redis_version: {{ mayan.redis_version | default("latest") }}
   rabbit_version: {{ mayan.rabbit_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 minecraft:
   enable: {{ minecraft.enable | default(False) }}
   https_only: {{ minecraft.https_only | default(False) }}
@@ -839,9 +839,9 @@ minecraft:
   subdomain: {{ minecraft.subdomain | default("minecraft") }}
   version: {{ minecraft.version | default("latest") }}
   server_version: {{ minecraft.server_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   online_mode: {{ minecraft.online_mode | default(True) }}
   server_type: {{ minecraft.server_type | default("vanilla") }}
 minecraftbedrockserver:
@@ -851,9 +851,9 @@ minecraftbedrockserver:
   domain: {{ minecraftbedrockserver.domain| default(False) }}
   subdomain: {{ minecraftbedrockserver.subdomain | default("minecraftbedrockserver") }}
   version: {{ minecraftbedrockserver.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   eula: {{ minecraftbedrockserver.eula | default("TRUE") }}
   server_name: {{ minecraftbedrockserver.server_name | default("VivumLab") }} #any string
   server_port: {{ minecraftbedrockserver.server_port | default("19132") }} #any integer, 19132 is default
@@ -880,9 +880,9 @@ miniflux:
   subdomain: {{ miniflux.subdomain | default("miniflux") }}
   version: {{ miniflux.version | default("2.0.21") }}
   db_version: {{ miniflux.db_version | default("10.1") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 minio:
   enable: {{ minio.enable | default(False) }}
   https_only: {{ minio.https_only | default(False) }}
@@ -890,9 +890,9 @@ minio:
   domain: {{ minio.domain | default(False) }}
   subdomain: {{ minio.subdomain | default("minio") }}
   version: {{ minio.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 monicahq:
   enable: {{ monicahq.enable | default(False) }}
   https_only: {{ monicahq.https_only | default(False) }}
@@ -901,9 +901,9 @@ monicahq:
   subdomain: {{ monicahq.subdomain | default("monicahq") }}
   version: {{ monicahq.version | default("latest") }}
   db_version: {{ monicahq.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 mstream:
   enable: {{ mstream.enable | default(False) }}
   https_only: {{ mstream.https_only | default(False) }}
@@ -911,9 +911,9 @@ mstream:
   domain: {{ mstream.domain | default(False) }}
   subdomain: {{ mstream.subdomain | default("mstream") }}
   version: {{ mstream.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 mylar:
   enable: {{ mylar.enable | default(False) }}
   https_only: {{ mylar.https_only | default(False) }}
@@ -921,9 +921,9 @@ mylar:
   domain: {{ mylar.domain | default(False) }}
   subdomain: {{ mylar.subdomain | default("mylar") }}
   version: {{ mylar.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 n8n:
   enable: {{ n8n.enable | default(False) }}
   https_only: {{ n8n.https_only | default(False) }}
@@ -931,9 +931,9 @@ n8n:
   domain: {{ n8n.domain| default(False) }}
   subdomain: {{ n8n.subdomain | default("n8n") }}
   version: {{ n8n.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 netdata:
   enable: {{ netdata.enable | default(False) }}
   https_only: {{ netdata.https_only | default(False) }}
@@ -941,9 +941,9 @@ netdata:
   domain: {{ netdata.domain | default(False) }}
   subdomain: {{ netdata.subdomain | default("netdata") }}
   version: {{ netdata.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 nextcloud:
   enable: {{ nextcloud.enable | default(False) }}
   https_only: {{ nextcloud.https_only | default(False) }}
@@ -953,9 +953,9 @@ nextcloud:
   version: {{ nextcloud.version | default("apache") }}
   db_version: {{ nextcloud.db_version | default("12-alpine") }}
   redis_version: {{ nextcloud.redis_version | default("5.0-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 nodered:
   enable: {{ nodered.enable | default(False) }}
   https_only: {{ nodered.https_only | default(False) }}
@@ -963,9 +963,9 @@ nodered:
   domain: {{ nodered.domain| default(False) }}
   subdomain: {{ nodered.subdomain | default("nodered") }}
   version: {{ nodered.version | default("latest-12-minimal") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   node_options: {{ nodered.node_options | default("") }}
   enable_projects: {{ nodered.enable_projects | default(False) }}
   safe_mode: {{ nodered.safe_mode | default(False) }}
@@ -976,9 +976,9 @@ nzbget:
   domain: {{ nzbget.domain | default(False) }}
   subdomain: {{ nzbget.subdomain | default("nzbget") }}
   version: {{ nzbget.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 octoprint:
   enable: {{ octoprint.enable | default(False) }}
   https_only: {{ octoprint.https_only | default(False) }}
@@ -987,9 +987,9 @@ octoprint:
   domain: {{ octoprint.domain | default(False) }}
   subdomain: {{ octoprint.subdomain | default("octoprint")}}
   version: {{ octoprint.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 ombi:
   enable: {{ ombi.enable | default(False) }}
   https_only: {{ ombi.https_only | default(False) }}
@@ -997,9 +997,9 @@ ombi:
   domain: {{ ombi.domain | default(False) }}
   subdomain: {{ ombi.subdomain | default("ombi") }}
   version: {{ ombi.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 openldap:
   enable: {{ openldap.enable | default(False) }}
   https_only: {{ openldap.https_only | default(False) }}
@@ -1008,9 +1008,9 @@ openldap:
   subdomain: {{ openldap.subdomain | default("openldap") }}
   version: {{ openldap.version | default("1.2.2") }}
   web_version: {{ openldap.web_version | default("0.7.2") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 openvpn:
   enable: {{ openvpn.enable | default(False) }}
   https_only: {{ openvpn.https_only | default(False) }}
@@ -1018,9 +1018,9 @@ openvpn:
   domain: {{ openvpn.domain | default(False) }}
   subdomain: {{ openvpn.subdomain | default("openvpn") }}
   version: {{ openvpn.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 organizr:
   enable: {{ organizr.enable | default(False) }}
   https_only: {{ organizr.https_only | default(False) }}
@@ -1028,9 +1028,9 @@ organizr:
   domain: {{ organizr.domain | default(False) }}
   subdomain: {{ organizr.subdomain | default("organizr") }}
   version: {{ organizr.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 ownphotos:
   enable: {{ ownphotos.enable | default(False) }}
   https_only: {{ ownphotos.https_only | default(False) }}
@@ -1040,9 +1040,9 @@ ownphotos:
   version: {{ ownphotos.version | default("dev") }}
   db_version: {{ ownphotos.db_version | default("latest") }}
   redis_version: {{ ownphotos.redis_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 paperless:
   enable: {{ paperless.enable | default(False) }}
   https_only: {{ paperless.https_only | default(False) }}
@@ -1050,9 +1050,9 @@ paperless:
   domain: {{ paperless.domain | default(False) }}
   subdomain: {{ paperless.subdomain | default("paperless") }}
   version: {{ paperless.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 peertube:
   enable: {{ peertube.enable | default(False) }}
   https_only: {{ peertube.https_only | default(False) }}
@@ -1062,9 +1062,9 @@ peertube:
   version: {{ peertube.version | default("production-buster") }}
   db_version: {{ peertube.db_version | default("10-alpine") }}
   redis_version: {{ peertube.redis_version | default("4-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 photoprism:
   enable: {{ photoprism.enable | default(False) }}
   https_only: {{ photoprism.https_only | default(False) }}
@@ -1072,9 +1072,9 @@ photoprism:
   domain: {{ photoprism.domain | default(False) }}
   subdomain: {{ photoprism.subdomain | default("photoprism") }}
   version: {{ photoprism.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 pihole:
   enable: {{ pihole.enable | default(False) }}
   https_only: {{ pihole.https_only | default(False) }}
@@ -1082,9 +1082,9 @@ pihole:
   domain: {{ pihole.domain | default(False) }}
   subdomain: {{ pihole.subdomain | default("pihole") }}
   version: {{ pihole.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 piwigo:
   enable: {{ piwigo.enable | default(False) }}
   https_only: {{ piwigo.https_only | default(False) }}
@@ -1093,9 +1093,9 @@ piwigo:
   subdomain: {{ piwigo.subdomain | default("piwigo") }}
   version: {{ piwigo.version | default("latest") }}
   db_version: {{ piwigo.db_version | default("10.4") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 pixelfed:
   enable: {{ pixelfed.enable | default(False) }}
   https_only: {{ pixelfed.https_only | default(False) }}
@@ -1105,9 +1105,9 @@ pixelfed:
   version: {{ pixelfed.version | default("latest") }}
   db_version: {{ pixelfed.db_version | default("10.4") }}
   redis_version: {{ pixelfed.redis_version | default("5-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 pleroma:
   enable: {{ pleroma.enable | default(False) }}
   https_only: {{ pleroma.https_only | default(False) }}
@@ -1116,9 +1116,9 @@ pleroma:
   subdomain: {{ pleroma.subdomain | default("pleroma") }}
   version: {{ pleroma.version | default("latest") }}
   db_version: {{ pleroma.db_version | default("9.6-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 plex:
   enable: {{ plex.enable | default(False) }}
   https_only: {{ plex.https_only | default(False) }}
@@ -1126,9 +1126,9 @@ plex:
   domain: {{ plex.domain | default(False) }}
   subdomain: {{ plex.subdomain | default("plex") }}
   version: {{ plex.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 poli:
   enable: {{ poli.enable | default(False) }}
   https_only: {{ poli.https_only | default(False) }}
@@ -1136,9 +1136,9 @@ poli:
   domain: {{ poli.domain | default(False) }}
   subdomain: {{ poli.subdomain | default("poli") }}
   version: {{ poli.version | default("0.10.1") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 portainer:
   enable: {{ portainer.enable | default(False) }}
   https_only: {{ portainer.https_only | default(False) }}
@@ -1146,9 +1146,9 @@ portainer:
   domain: {{ portainer.domain | default(False) }}
   subdomain: {{ portainer.subdomain | default("portainer") }}
   version: {{ portainer.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 privatebin:
   enable: {{ privatebin.enable | default(False) }}
   https_only: {{ privatebin.https_only | default(False) }}
@@ -1156,9 +1156,9 @@ privatebin:
   domain: {{ privatebin.domain | default(False) }}
   subdomain: {{ privatebin.subdomain | default("privatebin") }}
   version: {{ privatebin.version | default("1.3.4-alpine3.11") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 qbittorrent:
   enable: {{ qbittorrent.enable | default(False) }}
   https_only: {{ qbittorrent.https_only | default(False) }}
@@ -1168,9 +1168,9 @@ qbittorrent:
   version: {{ qbittorrent.version | default("latest") }}
   vpn_enabled: !!str '{{ qbittorrent.vpn_enabled | default(false) }}'
   lan_network: {{ qbittorrent.lan_network | default("192.168.1.0/24") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 radarr:
   enable: {{ radarr.enable | default(False) }}
   https_only: {{ radarr.https_only | default(False) }}
@@ -1178,9 +1178,9 @@ radarr:
   domain: {{ radarr.domain | default(False) }}
   subdomain: {{ radarr.subdomain | default("radarr") }}
   version: {{ radarr.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 readarr:
   enable: {{ readarr.enable | default(enable_readarr, None) | default(False) }}
   https_only: {{ readarr.https_only | default(False) }}
@@ -1188,9 +1188,9 @@ readarr:
   domain: {{ readarr.domain | default(False) }}
   subdomain: {{ readarr.subdomain | default("readarr")}}
   version: {{ readarr.version | default("unstable") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 restic:
   enable: {{ restic.enable | default(False) }}
   https_only: {{ restic.https_only | default(False) }}
@@ -1198,9 +1198,9 @@ restic:
   domain: {{ restic.domain | default(False) }}
   subdomain: {{ restic.subdomain | default("restic") }}
   version: {{ restic.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 rsshub:
   enable: {{ rsshub.enable | default(False) }}
   https_only: {{ rsshub.https_only | default(False) }}
@@ -1208,9 +1208,9 @@ rsshub:
   domain: {{ rsshub.domain | default(False) }}
   subdomain: {{ rsshub.subdomain | default("rsshub")}}
   version: {{ rsshub.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 sabnzbd:
   enable: {{ sabnzbd.enable | default(False) }}
   https_only: {{ sabnzbd.https_only | default(False) }}
@@ -1218,15 +1218,15 @@ sabnzbd:
   domain: {{ sabnzbd.domain | default(False) }}
   subdomain: {{ sabnzbd.subdomain | default("sabnzbd") }}
   version: {{ sabnzbd.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 samba:
   enable: {{ samba.enable | default(False) }}
   version: {{ samba.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 searx:
   enable: {{ searx.enable | default(False) }}
   https_only: {{ searx.https_only | default(False) }}
@@ -1234,9 +1234,9 @@ searx:
   domain: {{ searx.domain | default(False) }}
   subdomain: {{ searx.subdomain | default("searx") }}
   version: {{ searx.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 shinobi:
   enable: {{ shinobi.enable | default(False) }}
   https_only: {{ shinobi.https_only | default(False) }}
@@ -1245,9 +1245,9 @@ shinobi:
   subdomain: {{ shinobi.subdomain | default("shinobi") }}
   version: {{ shinobi.version | default("latest") }}
   db_version: {{ shinobi.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 sickchill:
   enable: {{ sickchill.enable | default(False) }}
   https_only: {{ sickchill.https_only | default(False) }}
@@ -1255,9 +1255,9 @@ sickchill:
   domain: {{ sickchill.domain | default(False) }}
   subdomain: {{ sickchill.subdomain | default("sickchill") }}
   version: {{ sickchill.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 simply_shorten:
   enable: {{ simply_shorten.enable | default(False) }}
   https_only: {{ simply_shorten.https_only | default(False) }}
@@ -1265,9 +1265,9 @@ simply_shorten:
   domain: {{ simply_shorten.domain | default(False) }}
   subdomain: {{ simply_shorten.subdomain | default("simply_shorten")}}
   version: {{ simply_shorten.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 snibox:
   enable: {{ snibox.enable | default(False) }}
   https_only: {{ snibox.https_only | default(False) }}
@@ -1277,9 +1277,9 @@ snibox:
   version: {{ snibox.version | default("latest") }}
   web_version: {{ snibox.web_version | default("1.15.9") }}
   db_version: {{ snibox.db_version | default("10.7-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 sonarr:
   enable: {{ sonarr.enable | default(False) }}
   https_only: {{ sonarr.https_only | default(False) }}
@@ -1287,9 +1287,9 @@ sonarr:
   domain: {{ sonarr.domain | default(False) }}
   subdomain: {{ sonarr.subdomain | default("sonarr") }}
   version: {{ sonarr.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 speedtest:
   enable: {{ speedtest.enable | default(False) }}
   https_only: {{ speedtest.https_only | default(False) }}
@@ -1297,9 +1297,9 @@ speedtest:
   domain: {{ speedtest.domain | default(False) }}
   subdomain: {{ speedtest.subdomain | default("speedtest") }}
   version: {{ speedtest.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
   server: {{ speedtest.server | default (11441) }}
 statping:
   enable: {{ statping.enable | default(False) }}
@@ -1308,9 +1308,9 @@ statping:
   domain: {{ statping.domain | default(False) }}
   subdomain: {{ statping.subdomain | default("statping") }}
   version: {{ statping.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 sui:
   enable: {{ sui.enable | default(True) }}
   https_only: {{ sui.https_only | default(False) }}
@@ -1318,9 +1318,9 @@ sui:
   domain: {{ sui.domain | default(False) }}
   subdomain: {{ sui.subdomain | default("sui") }}
   version: {{ sui.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 syncthing:
   enable: {{ syncthing.enable | default(False) }}
   https_only: {{ syncthing.https_only | default(False) }}
@@ -1328,9 +1328,9 @@ syncthing:
   domain: {{ syncthing.domain | default(False) }}
   subdomain: {{ syncthing.subdomain | default("syncthing") }}
   version: {{ syncthing.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 taisun:
   enable: {{ taisun.enable | default(False) }}
   https_only: {{ taisun.https_only | default(False) }}
@@ -1338,9 +1338,9 @@ taisun:
   domain: {{ taisun.domain | default(False) }}
   subdomain: {{ taisun.subdomain | default("taisun")}}
   version: {{ taisun.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 tautulli:
   enable: {{ tautulli.enable | default(False) }}
   https_only: {{ tautulli.https_only | default(False) }}
@@ -1348,9 +1348,9 @@ tautulli:
   domain: {{ tautulli.domain | default(False) }}
   subdomain: {{ tautulli.subdomain | default("tautulli") }}
   version: {{ tautulli.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 teedy:
   enable: {{ teedy.enable | default(False) }}
   https_only: {{ teedy.https_only | default(False) }}
@@ -1359,9 +1359,9 @@ teedy:
   subdomain: {{ teedy.subdomain | default("teedy")}}
   version: {{ teedy.version | default("v1.8") }}
   db_version: {{ teedy.db_version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 thelounge:
   enable: {{ thelounge.enable | default(False) }}
   https_only: {{ thelounge.https_only | default(False) }}
@@ -1369,9 +1369,9 @@ thelounge:
   domain: {{ thelounge.domain | default(False) }}
   subdomain: {{ thelounge.subdomain | default("thelounge") }}
   version: {{ thelounge.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 tick:
   enable: {{ tick.enable | default(False) }}
   https_only: {{ tick.https_only | default(False) }}
@@ -1382,9 +1382,9 @@ tick:
   influxdb_version: {{ tick.influxdb_version | default("latest") }}
   chronograf_version: {{ tick.chronograf_version | default("latest") }}
   kapacitor_version: {{ tick.kapacitor_version | default("1.3.3") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 tiddlywiki:
   enable: {{ tiddlywiki.enable | default(False) }}
   https_only: {{ tiddlywiki.https_only | default(False) }}
@@ -1392,9 +1392,9 @@ tiddlywiki:
   domain: {{ tiddlywiki.domain| default(False) }}
   subdomain: {{ tiddlywiki.subdomain | default("tiddlywiki") }}
   version: {{ tiddlywiki.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 transmission:
   enable: {{ transmission.enable | default(False) }}
   https_only: {{ transmission.https_only | default(False) }}
@@ -1402,9 +1402,9 @@ transmission:
   domain: {{ transmission.domain | default(False) }}
   subdomain: {{ transmission.subdomain | default("transmission") }}
   version: {{ transmission.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 trilium:
   enable: {{ trilium.enable | default(False) }}
   https_only: {{ trilium.https_only | default(False) }}
@@ -1412,18 +1412,18 @@ trilium:
   domain: {{ trilium.domain| default(False) }}
   subdomain: {{ trilium.subdomain | default("trilium") }}
   version: {{ trilium.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 turtl:
   enable: {{ turtl.enable | default(False) }}
   https_only: {{ turtl.https_only | default(False) }}
   auth: {{ turtl.auth | default(False) }}
   domain: {{ turtl.domain| default(False) }}
   subdomain: {{ turtl.subdomain | default("turtl") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 ubooquity:
   enable: {{ ubooquity.enable | default(False) }}
   https_only: {{ ubooquity.https_only | default(False) }}
@@ -1431,9 +1431,9 @@ ubooquity:
   domain: {{ ubooquity.domain | default(False) }}
   subdomain: {{ ubooquity.subdomain | default("ubooquity") }}
   version: {{ ubooquity.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 unificontroller:
   enable: {{ unificontroller.enable | default(False) }}
   https_only: {{ unificontroller.https_only | default(False) }}
@@ -1441,9 +1441,9 @@ unificontroller:
   domain: {{ unificontroller.domain | default(False) }}
   subdomain: {{ unificontroller.subdomain | default("unificontroller")}}
   version: {{ unificontroller.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 wallabag:
   enable: {{ wallabag.enable | default(False) }}
   https_only: {{ wallabag.https_only | default(False) }}
@@ -1453,18 +1453,18 @@ wallabag:
   version: {{ wallabag.version | default("latest") }}
   db_version: {{ wallabag.db_version | default("10.4") }}
   redis_version: {{ wallabag.redis_version | default("alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 watchtower:
   enable: {{ watchtower.enable |  default(False) }}
   domain: False #Needed for ansible
   subdomain: False #Needed for ansible
   notification: {{ watchtower.notification | default (False) }}
   version: {{ watchtower.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 {% raw %}
   gotify_token: "{{ vault.watchtower.gotify_token | default (False) }}"
 {% endraw %}
@@ -1476,9 +1476,9 @@ webtrees:
   subdomain: {{ webtrees.subdomain | default("webtrees") }}
   version: {{ webtrees.version | default("latest") }}
   db_version: {{ webtrees.db_version | default("10.4") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 webdavserver:
   enable: {{ webdavserver.enable | default(False) }}
   https_only: {{ webdavserver.https_only | default(False) }}
@@ -1486,9 +1486,9 @@ webdavserver:
   domain: {{ webdavserver.domain| default(False) }}
   subdomain: {{ webdavserver.subdomain | default("webdav") }}
   version: {{ webdavserver.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 webvirtmgr:
   enable: {{ webvirtmgr.enable | default(False) }}
   https_only: {{ webvirtmgr.https_only | default(False) }}
@@ -1496,9 +1496,9 @@ webvirtmgr:
   domain: {{ webvirtmgr.domain | default(False) }}
   subdomain: {{ webvirtmgr.subdomain | default("webvirtmgr") }}
   version: {{ webvirtmgr.version | default("latest") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 wekan:
   enable: {{ wekan.enable | default(False) }}
   https_only: {{ wekan.https_only | default(False) }}
@@ -1507,9 +1507,9 @@ wekan:
   subdomain: {{ wekan.subdomain | default("wekan") }}
   version: {{ wekan.version | default("latest") }}
   db_version: {{ wekan.db_version | default("3.2.12") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 zammad:
   enable: {{ zammad.enable | default(False) }}
   https_only: {{ zammad.https_only | default(False) }}
@@ -1518,9 +1518,9 @@ zammad:
   subdomain: {{ zammad.subdomain | default("zammad") }}
   version: {{ zammad.version | default("3.4.0-17") }}
   memcached_version: {{ zammad.memcached_version | default("1.5.22-alpine") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 zulip:
   enable: {{ zulip.enable | default(False) }}
   https_only: {{ zulip.https_only | default(False) }}
@@ -1531,9 +1531,9 @@ zulip:
   db_version: {{ zulip.db_version | default("latest") }}
   redis_version: {{ zulip.redis_version | default("latest") }}
   rabbit_version: {{ zulip.rabbit_version | default("3.7.7") }}
-  amd64: False # False or verified or supported or unsupported
-  arm64: False # False or verified or supported or unsupported
-  armv7: False # False or verified or supported or unsupported
+  amd64: False
+  arm64: False
+  armv7: False
 
 ### OPTIONAL ### These valuse are OPTIONAL and enable extra VivumLab functionality.
 


### PR DESCRIPTION
All of this repetitive commenting seems a bit counter-productive..

I've been thinking that the comments, are actually directed at the devs, so why not place this information into the documentation?

The documentation has been updated; the necessary information now exists in the developer document

If there are any issues with this, please bring it up sooner, rather than later