### PR TITLE
chore(ci): mirror master to dev when release

### DIFF
--- a/.github/workflows/04-release.yml
+++ b/.github/workflows/04-release.yml
@@ -35,7 +35,7 @@ jobs:
             @semantic-release/git
             @semantic-release/github
             @semantic-release/release-notes-generator
-      - name: Do something when a new release published
+      - name: Echo release
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           echo ${{ steps.semantic.outputs.new_release_version }}
@@ -70,7 +70,7 @@ jobs:
             @semantic-release/git
             @semantic-release/github
             @semantic-release/release-notes-generator
-      - name: Do something when a new release published
+      - name: Echo release
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
           echo ${{ steps.semantic.outputs.new_release_version }}

--- a/.github/workflows/06-mirror-back-to-dev.yml
+++ b/.github/workflows/06-mirror-back-to-dev.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  mirror_job:
+    runs-on: ubuntu-latest
+    if: steps.semantic.outputs.new_release_published == 'true'
+    name: Mirror master branch to dev branch
+    steps:
+    - name: Mirror action step
+      id: mirror
+      uses: google/mirror-branch-action@v1.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        source: 'master'
+        dest: 'dev'


### PR DESCRIPTION
Finally getting rid of the manual step when creating a release.