### PR TITLE
chore(ci): remove double build and deploy to docker

### DIFF
--- a/.github/workflows/03-release.yml
+++ b/.github/workflows/03-release.yml
@@ -93,11 +93,3 @@ jobs:
           github-token: ${{ secrets.DE_PAT }}
           source: 'master'
           dest: 'dev'
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: vivumlab/vivumlab
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_semver: true
-          tags: "latest,${{ steps.semantic.outputs.new_release_version }}"


### PR DESCRIPTION
removes unnecessary step which builds and deploy multiple times to docker