### PR TITLE
fix(setup): use python3 with debinstall

### DIFF
--- a/roles/vivumlab_setup/tasks/debinstall.yml
+++ b/roles/vivumlab_setup/tasks/debinstall.yml
@@ -23,15 +23,10 @@
       - wget
       - whois
       - zsh
-      - python-virtualenv
-      - python-openssl
-      - python-setuptools
-      - python-passlib
-      # - python3-virtualenv
-      # - python3-openssl
-      # - python3-setuptools
-      # - python3-passlib
-      - python-pip
+      - python3-virtualenv
+      - python3-openssl
+      - python3-setuptools
+      - python3-passlib
       - python3-pip
   tags:
     - dependencies


### PR DESCRIPTION
post wireguard fix (ansible python interpreter change)
debinstall needs to install passlib, virtualenv, etc with python3, not python

this is the fix