### PR TITLE
fix: nextcloud

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -14,6 +14,14 @@
     - "build"
   become: yes
 
+- name: Create necessary Media Folders / NAS Mount Points
+  file:
+    path: "{{ storage_dir }}/Documents/NextCloud/data"
+    state: directory
+    owner: "{{ uid_output.stdout }}"
+    group: "{{ gid_output.stdout }}"
+  become: yes  # /mnt is owned by root
+
 - name: Copy nextcloud web Dockerfile into place.
   copy:
     src: "web/Dockerfile"

--- a/roles/vivumlab_deploy/tasks/main.yml
+++ b/roles/vivumlab_deploy/tasks/main.yml
@@ -53,6 +53,8 @@
   file:
     path: "{{ storage_dir }}/{{ item }}"
     state: directory
+    owner: "{{ uid_output.stdout }}"
+    group: "{{ gid_output.stdout }}"
   with_items:
     - "Backups"
     - "Books"
@@ -62,6 +64,7 @@
     - "Pictures"
     - "temp"
     - "Video"
+  become: yes
 
 - name: Configure NAS - Public NFS Shares
   when:


### PR DESCRIPTION
May partially fix https://github.com/VivumLab/VivumLab/issues/317

Nextcloud could not write into the `data/` directory because it was being created automatically by docker as it didn't exist.

This PR may contribute to fixing that by:
1. Ensure the Shared Mounts directories are always owned by the user, not by root (default for `/mnt`)
2. Ensure the Nextcloud role creates the necessary directories before launching the container.

The other commit present is more of a suggestion/question: I was also getting some permission errors when launching the container because it couldn't access the `entrypoint`. To fix that, I am skipping the build and using the image directly. However, what would be the correct fix? And why is the build necessary?