### PR TITLE
feat: allow to set custom traefik env server

### DIFF
--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -133,6 +133,7 @@ traefik:
   domain: {{ traefik.domain | default(False) }}
   subdomain: {{ traefik.subdomain | default("traefik") }}
   auth: {{ traefik.auth | default(False) }}
+  acme_server: {{ traefik.acme_server | default("https://acme-v02.api.letsencrypt.org/directory") }}
   expose_internally: {{ traefik.expose_internally | default(True) }}
   expose_externally: {{ traefik.expose_externally | default(False) }}
   ping: {{ traefik.ping | default(False) }}

--- a/roles/vivumlab_deploy/templates/traefik.yaml
+++ b/roles/vivumlab_deploy/templates/traefik.yaml
@@ -117,7 +117,7 @@ log:
 certificatesResolvers:
   dns:
     acme:
-      caServer: https://acme-v02.api.letsencrypt.org/directory
+      caServer: {{ traefik.acme_server }}
       email: {{ ((admin_email == None) | ternary('test@test.com', admin_email)) }}
       keyType: EC256
       storage: acme.json
@@ -129,7 +129,7 @@ certificatesResolvers:
           - '1.0.0.1:53'
   http:
     acme:
-      caServer: https://acme-v02.api.letsencrypt.org/directory
+      caServer: {{ traefik.acme_server }}
       email: {{ ((admin_email == None) | ternary('test@test.com', admin_email)) }}
       keyType: EC256
       storage: acme.json


### PR DESCRIPTION
We might want to test first without worrying to much about LE's limits,
so this would be an easier way of pointing to the staging servers:
https://acme-staging-v02.api.letsencrypt.org/directory

(See https://letsencrypt.org/docs/staging-environment/)