### PR TITLE
fix: start ssh agent and add keys at start

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,4 +27,13 @@ clear
 
 cat /etc/motd
 
+echo "Starting ssh agent and adding your key."
+eval "$(ssh-agent -s)"
+for key in /root/.ssh/*; do
+  if [ "${key: -4}" == ".pub" ]; then
+    continue
+  fi
+  ssh-add $key
+done
+
 exec "$@"


### PR DESCRIPTION
Fixes #316

Start the ssh agent and add all the added keys to it to avoid the error in the related issue.
Following the suggestions there solves the issue, so this adds those commands to the entrypoint to make it easier.