### PR TITLE
feat: add another DB option to nextcloud

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Check if nextcloud configuration is correct
+  assert:
+    msg: One (and only one) of the databases should be enabled (PostgreSQL/MariaDB)
+    that:
+      - not(nextcloud.postgres and nextcloud.mariadb)
+      - nextcloud.postgres or nextcloud.mariadb
+
 - name: Create necessary folders, with appropriate permissions.
   file:
     path: "{{ volumes_root }}/nextcloud/{{ item }}"
@@ -6,12 +13,14 @@
     owner: "{{ uid_output.stdout }}"
     group: "{{ gid_output.stdout }}"
   with_items:
-    - "config"
-    - "custom_apps"
-    - "themes"
-    - "postgres"
-    - "web"
-    - "build"
+    - config
+    - custom_apps
+    - themes
+    # create both DB dirs just in case (e.g. migrations)
+    - postgres
+    - mariadb
+    - web
+    - build
   become: yes
 
 - name: Create necessary Media Folders / NAS Mount Points

--- a/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
+++ b/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
@@ -8,9 +8,10 @@ networks:
   nextcloud:
 
 services:
+  {% if nextcloud.postgres -%}
   db:
     container_name: nextcloud_db
-    image: postgres:{{ nextcloud.db_version }}
+    image: postgres:{{ nextcloud.postgres_version }}
     restart: unless-stopped
     volumes:
       - "{{ volumes_root }}/nextcloud/postgres:/var/lib/postgresql/data"
@@ -21,6 +22,22 @@ services:
       - POSTGRES_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
       - POSTGRES_USER=nextcloud
       - POSTGRES_DB=nextcloud
+  {% elif nextcloud.mariadb -%}
+  db:
+    container_name: nextcloud_db
+    image: mariadb:{{ nextcloud.mariadb_version }}
+    restart: unless-stopped
+    volumes:
+      - "{{ volumes_root }}/nextcloud/mariadb:/var/lib/mysql"
+    networks:
+      - nextcloud
+    restart: unless-stopped
+    environment:
+      - MYSQL_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
+      - MYSQL_USER=nextcloud
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_ROOT_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
+  {% endif %}
 
   redis:
     container_name: nextcloud_redis
@@ -45,10 +62,17 @@ services:
     environment:
       - UID={{ uid_output.stdout }}
       - GID={{ gid_output.stdout }}
+      {% if nextcloud.postgres -%}
       - POSTGRES_HOST=db
       - POSTGRES_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
       - POSTGRES_DB=nextcloud
       - POSTGRES_USER=nextcloud
+      {% elif nextcloud.mariadb -%}
+      - MYSQL_HOST=db
+      - MYSQL_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
+      - MYSQL_DATABASE=nextcloud
+      - MYSQL_USER=nextcloud
+      {% endif -%}
       - UPLOAD_MAX_SIZE=10G
       - APC_SHM_SIZE=128M
       - OPCACHE_MEM_SIZE=128
@@ -62,7 +86,6 @@ services:
       # SMTP settings
       - SMTP_HOST={{ smtp.host }}
       - SMTP_SECURE={% if smtp.port == 587 %}ssl{% endif %}
-
       - SMTP_PORT={{ smtp.port }}
       - SMTP_PASSWORD={{ smtp.pass }}
       - MAIL_FROM_ADDRESS={{ smtp.from_email }}

--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -1000,7 +1000,10 @@ nextcloud:
   domain: {{ nextcloud.domain | default(False) }}
   subdomain: {{ nextcloud.subdomain | default("nextcloud") }}
   version: {{ nextcloud.version | default("21") }}
-  db_version: {{ nextcloud.db_version | default("12-alpine") }}
+  postgres: {{ nextcloud.postgres | default(True) }}
+  postgres_version: {{ nextcloud.postgres_version | default("12-alpine") }}
+  mariadb: {{ nextcloud.mariadb | default(False) }}
+  mariadb_version: {{ nextcloud.mariadb_version | default("10.5.3") }}
   redis_version: {{ nextcloud.redis_version | default("5.0-alpine") }}
   amd64: False
   arm64: False


### PR DESCRIPTION
Allow to use MariaDB as an alternative to PostgreSQL
MariaDB/MySQL is the recommended DB engine by NC:
https://docs.nextcloud.com/server/20/admin_manual/configuration_database/linux_database_configuration.html#database-configuration

This allows you to choose between both (while keeping PG as the default)

It also provides a good template if you want to have both at the same time (for migrating between them, for example)