### PR TITLE
feat: add other image options to nextcloud

### DIFF
--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -8,27 +8,41 @@
 
 - name: Create necessary folders, with appropriate permissions.
   file:
-    path: "{{ volumes_root }}/nextcloud/{{ item }}"
+    path: "{{ volumes_root }}/nextcloud/{{ item.name }}"
     state: directory
-    owner: "{{ uid_output.stdout }}"
-    group: "{{ gid_output.stdout }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
   with_items:
-    - config
-    - custom_apps
-    - themes
+    - name: config
+      owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+      group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
+    - name: custom_apps
+      owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+      group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
+    - name: themes
+      owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+      group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
     # create both DB dirs just in case (e.g. migrations)
-    - postgres
-    - mariadb
-    - web
-    - build
+    - name: postgres
+      owner: "{{ uid_output.stdout }}"
+      group: "{{ gid_output.stdout }}"
+    - name: mariadb
+      owner: 999
+      group: 999
+    - name: web
+      owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+      group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
+    - name: build
+      owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+      group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
   become: yes
 
 - name: Create necessary Media Folders / NAS Mount Points
   file:
     path: "{{ storage_dir }}/Documents/NextCloud/data"
     state: directory
-    owner: "{{ uid_output.stdout }}"
-    group: "{{ gid_output.stdout }}"
+    owner: "{{ uid_output.stdout if nextcloud.system_user else '33' }}"
+    group: "{{ gid_output.stdout if nextcloud.system_user else '33' }}"
   become: yes  # /mnt is owned by root
 
 - name: Copy nextcloud web Dockerfile into place.

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -32,6 +32,7 @@
   become: yes  # /mnt is owned by root
 
 - name: Copy nextcloud web Dockerfile into place.
+  when: nextcloud.image_type == "fpm-alpine"
   copy:
     src: "web/Dockerfile"
     dest: "{{ volumes_root }}/nextcloud/web/Dockerfile"
@@ -40,6 +41,7 @@
   become: yes
 
 - name: Copy nextcloud web nginx.conf into place.
+  when: nextcloud.image_type == "fpm-alpine"
   copy:
     src: "web/nginx.conf"
     dest: "{{ volumes_root }}/nextcloud/web/nginx.conf"
@@ -48,6 +50,7 @@
   become: yes
 
 - name: Copy nextcloud build Dockerfile into place.
+  when: nextcloud.image_type == "fpm-alpine"
   template:
     src: Dockerfile.j2
     dest: "{{ volumes_root }}/nextcloud/build/Dockerfile"
@@ -56,6 +59,7 @@
   become: yes
 
 - name: Copy nextcloud build entrypoint.sh into place.
+  when: nextcloud.image_type == "fpm-alpine"
   copy:
     src: "build/entrypoint.sh"
     dest: "{{ volumes_root }}/nextcloud/build/entrypoint.sh"

--- a/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
+++ b/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
@@ -48,10 +48,17 @@ services:
 
   nextcloud:
     container_name: nextcloud
+    {% if nextcloud.image_type == "fpm-alpine" -%}
     build: ./build
+    {% else -%}
+    image: nextcloud:{{ nextcloud.version }}-{{ nextcloud.image_type }}
+    {% endif -%}
     restart: unless-stopped
     user: "{{ uid_output.stdout }}:{{ gid_output.stdout }}"
     networks:
+      {% if nextcloud.image_type != "fpm-alpine" -%}
+      - traefik_network
+      {% endif -%}
       - nextcloud
     volumes:
       - "nextcloud:/var/www/html"
@@ -91,10 +98,17 @@ services:
       - MAIL_FROM_ADDRESS={{ smtp.from_email }}
       - OVERWRITEHOST={{ service_domain }}
       - OVERWRITEPROTOCOL=https
+    {% if nextcloud.image_type != "fpm-alpine" -%}
+    labels:
+      - "traefik.http.services.nextcloud.loadbalancer.server.scheme=http"
+      - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
+{% include './labels.j2' %}
+    {% endif -%}
     depends_on:
       - db
       - redis
 
+  {% if nextcloud.image_type == "fpm-alpine" -%}
   web:
     build: ./web
     restart: unless-stopped
@@ -109,6 +123,7 @@ services:
       - "traefik.http.services.nextcloud.loadbalancer.server.scheme=http"
       - "traefik.http.services.nextcloud.loadbalancer.server.port=80"
 {% include './labels.j2' %}
+  {% endif %}
 
 volumes:
   nextcloud:

--- a/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
+++ b/roles/nextcloud/templates/docker-compose.nextcloud.yml.j2
@@ -54,7 +54,9 @@ services:
     image: nextcloud:{{ nextcloud.version }}-{{ nextcloud.image_type }}
     {% endif -%}
     restart: unless-stopped
+    {% if nextcloud.system_user -%}
     user: "{{ uid_output.stdout }}:{{ gid_output.stdout }}"
+    {% endif -%}
     networks:
       {% if nextcloud.image_type != "fpm-alpine" -%}
       - traefik_network
@@ -67,8 +69,10 @@ services:
       - "{{ volumes_root }}/nextcloud/themes:/var/www/html/themes"
       - "{{ storage_dir }}/Documents/NextCloud/data:/var/www/html/data"
     environment:
+      {% if nextcloud.system_user -%}
       - UID={{ uid_output.stdout }}
       - GID={{ gid_output.stdout }}
+      {% endif -%}
       {% if nextcloud.postgres -%}
       - POSTGRES_HOST=db
       - POSTGRES_PASSWORD={{lookup('password', './settings/' + config_dir + '/passwords/nextcloud_db_password chars=ascii_letters')}}
@@ -92,7 +96,9 @@ services:
       - NEXTCLOUD_UPDATE=1 # triggers the automated install on first run.
       # SMTP settings
       - SMTP_HOST={{ smtp.host }}
-      - SMTP_SECURE={% if smtp.port == 587 %}ssl{% endif %}
+      {% if smtp.port == 587 -%}
+      - SMTP_SECURE=ssl
+      {% endif -%}
       - SMTP_PORT={{ smtp.port }}
       - SMTP_PASSWORD={{ smtp.pass }}
       - MAIL_FROM_ADDRESS={{ smtp.from_email }}

--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -1020,6 +1020,7 @@ nextcloud:
   domain: {{ nextcloud.domain | default(False) }}
   subdomain: {{ nextcloud.subdomain | default("nextcloud") }}
   version: {{ nextcloud.version | default("21") }}
+  image_type: {{ nextcloud.image_type | default("fpm-alpine") }}
   postgres: {{ nextcloud.postgres | default(True) }}
   postgres_version: {{ nextcloud.postgres_version | default("12-alpine") }}
   mariadb: {{ nextcloud.mariadb | default(False) }}

--- a/roles/vivumlab_config/templates/config.yml
+++ b/roles/vivumlab_config/templates/config.yml
@@ -1021,6 +1021,7 @@ nextcloud:
   subdomain: {{ nextcloud.subdomain | default("nextcloud") }}
   version: {{ nextcloud.version | default("21") }}
   image_type: {{ nextcloud.image_type | default("fpm-alpine") }}
+  system_user: {{ nextcloud.system_user | default(True) }}
   postgres: {{ nextcloud.postgres | default(True) }}
   postgres_version: {{ nextcloud.postgres_version | default("12-alpine") }}
   mariadb: {{ nextcloud.mariadb | default(False) }}


### PR DESCRIPTION
### Allow to use a different image type in NC

We can choose to have the `apache` version instead of the `fpm-alpine` one

This also skips the local build, as it was causing problems for me in particular, when migrating from an existing server

As the local build with the changes is skipped, if this is chosen, the user needs to take care of setting up the proper folder permissions, which can be done with the option added next

---

### Allow to use the custom 33:33 user for NC instead of system user

This was causing issues for me when migrating from an existing instance.

It will potentially break compatibility if we wanted shared volumes between NC and other services, but the NC folder structure already makes it pretty complicated, so I think it won't  cause problems
Still, this is an option that is not enabled by default and should be used with caution, and is essential if we wanted the previous option of using a different image type without a local build.


